### PR TITLE
fix(plugin): fix edit links pointing to temp files instead of source schemas

### DIFF
--- a/demo/docs/event-reference/01-complex-event.mdx
+++ b/demo/docs/event-reference/01-complex-event.mdx
@@ -2,7 +2,7 @@
 title: Complex Event with Validation Constraints
 description: "A generic event demonstrating various validation constraints and recursive documentation capabilities."
 sidebar_label: Complex Event with Validation Constraints
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/01-complex-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/complex-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/02-purchase-event.mdx
+++ b/demo/docs/event-reference/02-purchase-event.mdx
@@ -2,7 +2,7 @@
 title: Purchase Event
 description: "A purchase event fires when a user completes a purchase. Based on Google Analytics 4 ecommerce event specifications."
 sidebar_label: Purchase Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/02-purchase-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/purchase-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/03-add-to-cart-event.mdx
+++ b/demo/docs/event-reference/03-add-to-cart-event.mdx
@@ -2,7 +2,7 @@
 title: Add to Cart Event
 description: "An add_to_cart event fires when a user adds one or more items to their shopping cart. Based on Google Analytics 4 ecommerce event specifications."
 sidebar_label: Add to Cart Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/03-add-to-cart-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/add-to-cart-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/04-root-any-of-event.mdx
+++ b/demo/docs/event-reference/04-root-any-of-event.mdx
@@ -2,7 +2,7 @@
 title: Root AnyOf Event
 description: "An example event that has anyOf at the root level."
 sidebar_label: Root AnyOf Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/04-root-any-of-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/root-any-of-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/05-root-choice-event/01-option_a.mdx
+++ b/demo/docs/event-reference/05-root-choice-event/01-option_a.mdx
@@ -2,7 +2,7 @@
 title: Option A
 description: "This is the description for Param A."
 sidebar_label: Option A
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/05-root-choice-event/01-option_a.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/05-root-choice-event/02-option_b.mdx
+++ b/demo/docs/event-reference/05-root-choice-event/02-option_b.mdx
@@ -2,7 +2,7 @@
 title: Option B
 description: "An example event that has oneOf at the root level."
 sidebar_label: Option B
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/05-root-choice-event/02-option_b.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/docs/event-reference/06-choice-event.mdx
+++ b/demo/docs/event-reference/06-choice-event.mdx
@@ -2,7 +2,7 @@
 title: Choice Event
 description: "An example event that uses oneOf and anyOf."
 sidebar_label: Choice Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/event-reference/06-choice-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/01-complex-event.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/01-complex-event.mdx
@@ -2,7 +2,7 @@
 title: Complex Event with Validation Constraints
 description: "A generic event demonstrating various validation constraints and recursive documentation capabilities."
 sidebar_label: Complex Event with Validation Constraints
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/01-complex-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/complex-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/02-purchase-event.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/02-purchase-event.mdx
@@ -2,7 +2,7 @@
 title: Purchase Event
 description: "A purchase event fires when a user completes a purchase. Based on Google Analytics 4 ecommerce event specifications."
 sidebar_label: Purchase Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/02-purchase-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/purchase-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/03-add-to-cart-event.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/03-add-to-cart-event.mdx
@@ -2,7 +2,7 @@
 title: Add to Cart Event
 description: "An add_to_cart event fires when a user adds one or more items to their shopping cart. Based on Google Analytics 4 ecommerce event specifications."
 sidebar_label: Add to Cart Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/03-add-to-cart-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/add-to-cart-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/04-root-any-of-event.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/04-root-any-of-event.mdx
@@ -2,7 +2,7 @@
 title: Root AnyOf Event
 description: "An example event that has anyOf at the root level."
 sidebar_label: Root AnyOf Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/04-root-any-of-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/root-any-of-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/01-option_a.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/01-option_a.mdx
@@ -2,7 +2,7 @@
 title: Option A
 description: "This is the description for Param A."
 sidebar_label: Option A
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/01-option_a.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/02-option_b.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/02-option_b.mdx
@@ -2,7 +2,7 @@
 title: Option B
 description: "An example event that has oneOf at the root level."
 sidebar_label: Option B
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/02-option_b.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/demo/versioned_docs/version-1.2.0/event-reference/06-choice-event.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/06-choice-event.mdx
@@ -2,7 +2,7 @@
 title: Choice Event
 description: "An example event that uses oneOf and anyOf."
 sidebar_label: Choice Event
-custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/versioned_docs/version-1.2.0/event-reference/06-choice-event.json
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.anchor.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.anchor.test.js.snap
@@ -25,7 +25,7 @@ exports[`generateEventDocs (oneOf with $anchor) should generate documentation us
 title: Child Event Anchor
 description: "This is a child event with an anchor."
 sidebar_label: Child Event Anchor
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/docs/parent-event-anchor/01-child-event-with-anchor.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/static/schemas/parent-event-anchor.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';
@@ -54,7 +54,7 @@ exports[`generateEventDocs (oneOf with $anchor) should generate documentation us
 title: Child Event Title
 description: "This is a child event with only a title."
 sidebar_label: Child Event Title
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/docs/parent-event-anchor/02-child-event-title.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/static/schemas/parent-event-anchor.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.nested.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.nested.test.js.snap
@@ -44,7 +44,7 @@ exports[`generateEventDocs (nested oneOf) should generate nested documentation c
 title: Grandchild A
 description: undefined
 sidebar_label: Grandchild A
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/docs/parent-event/01-child-event/01-grandchild-a.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/child-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';
@@ -73,7 +73,7 @@ exports[`generateEventDocs (nested oneOf) should generate nested documentation c
 title: Grandchild B
 description: undefined
 sidebar_label: Grandchild B
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/docs/parent-event/01-child-event/02-grandchild-b.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/child-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.test.js.snap
@@ -112,7 +112,7 @@ exports[`generateEventDocs (non-versioned) should generate documentation correct
 title: Option A
 description: "An example event that has oneOf at the root level."
 sidebar_label: Option A
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/docs/root-choice-event/01-option-a.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';
@@ -141,7 +141,7 @@ exports[`generateEventDocs (non-versioned) should generate documentation correct
 title: Option B
 description: "An example event that has oneOf at the root level."
 sidebar_label: Option B
-custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/docs/root-choice-event/02-option-b.json
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json
 ---
 
 import SchemaViewer from '@theme/SchemaViewer';

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.anchor.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.anchor.test.js
@@ -61,11 +61,18 @@ describe('generateEventDocs (oneOf with $anchor)', () => {
       'utf-8',
     );
     expect(childWithAnchor).toMatchSnapshot();
+    // Inline oneOf options (using $anchor for slug) must link to the parent schema file
+    expect(childWithAnchor).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/static/schemas/parent-event-anchor.json',
+    );
 
     const childWithTitle = fs.readFileSync(
       path.join(parentDir, '02-child-event-title.mdx'),
       'utf-8',
     );
     expect(childWithTitle).toMatchSnapshot();
+    expect(childWithTitle).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/static/schemas/parent-event-anchor.json',
+    );
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.nested.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.nested.test.js
@@ -70,11 +70,18 @@ describe('generateEventDocs (nested oneOf)', () => {
       'utf-8',
     );
     expect(grandchildA).toMatchSnapshot();
+    // Nested $ref-based oneOf options must link to the resolved source schema file
+    expect(grandchildA).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/child-event.json',
+    );
 
     const grandchildB = fs.readFileSync(
       path.join(childDir, '02-grandchild-b.mdx'),
       'utf-8',
     );
     expect(grandchildB).toMatchSnapshot();
+    expect(grandchildB).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/child-event.json',
+    );
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
@@ -80,11 +80,18 @@ describe('generateEventDocs (non-versioned)', () => {
       'utf-8',
     );
     expect(rootChoiceA).toMatchSnapshot();
+    // Inline oneOf options must link to the parent schema file, not a temp output file
+    expect(rootChoiceA).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json',
+    );
 
     const rootChoiceB = fs.readFileSync(
       path.join(choiceEventDir, '02-option-b.mdx'),
       'utf-8',
     );
     expect(rootChoiceB).toMatchSnapshot();
+    expect(rootChoiceB).toContain(
+      'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json',
+    );
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
@@ -14,6 +14,7 @@ async function generateAndWriteDoc(
   outputDir,
   options,
   alreadyMergedSchema = null,
+  editFilePath = null,
 ) {
   const { organizationName, projectName, siteDir, dataLayerName, version } =
     options;
@@ -45,7 +46,7 @@ async function generateAndWriteDoc(
 
   const editUrl = `${baseEditUrl}/${path.relative(
     path.join(siteDir, '..'),
-    filePath,
+    editFilePath || filePath,
   )}`;
 
   const mdxContent = SchemaDocTemplate({
@@ -84,7 +85,7 @@ async function generateOneOfDocs(
 
   for (const [
     index,
-    { slug, schema: processedSchema },
+    { slug, schema: processedSchema, sourceFilePath },
   ] of processed.entries()) {
     const subChoiceType = processedSchema.oneOf ? 'oneOf' : null;
     const prefixedSlug = `${(index + 1).toString().padStart(2, '0')}-${slug}`;
@@ -95,7 +96,7 @@ async function generateOneOfDocs(
       await generateOneOfDocs(
         prefixedSlug,
         processedSchema,
-        tempFilePath,
+        sourceFilePath || tempFilePath,
         eventOutputDir,
         options,
       );
@@ -110,6 +111,7 @@ async function generateOneOfDocs(
         eventOutputDir,
         options,
         processedSchema,
+        sourceFilePath || filePath,
       );
       fs.unlinkSync(tempFilePath);
     }

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schema-processing.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schema-processing.js
@@ -25,8 +25,10 @@ export async function processOneOfSchema(schema, filePath) {
 
     for (const option of schema[choiceType]) {
       let resolvedOption = option;
+      let sourceFilePath = null;
       if (option.$ref && !option.$ref.startsWith('#')) {
         const refPath = path.resolve(path.dirname(filePath), option.$ref);
+        sourceFilePath = refPath;
         resolvedOption = await processSchema(refPath);
       }
 
@@ -54,6 +56,7 @@ export async function processOneOfSchema(schema, filePath) {
       processedSchemas.push({
         slug,
         schema: newSchema,
+        sourceFilePath,
       });
     }
   }


### PR DESCRIPTION
## Summary

- **Root cause**: When generating docs for `oneOf` schemas, the plugin wrote temporary JSON files to the output directory and used those paths for `custom_edit_url`. This caused edit links to point to non-existent `.json` files in the docs directory instead of the actual source schema files.
- **Fix**: Track the resolved `sourceFilePath` per option in `processOneOfSchema` when an option is loaded via `$ref`, and thread it through to `generateAndWriteDoc` via a new `editFilePath` parameter. Inline options (no `$ref`) fall back to the parent schema file path.
- **Regenerated docs**: All affected `custom_edit_url` values in `demo/docs/` and `demo/versioned_docs/version-1.2.0/` are now updated to point to the correct source schema files.

## Test plan

- [x] All 120 existing Jest tests pass
- [x] Updated snapshots for the 6 affected `custom_edit_url` values
- [x] Added explicit `toContain` assertions in 3 test files to prevent silent regression via snapshot updates:
  - `generateEventDocs.test.js` — inline `oneOf` (no `$ref`)
  - `generateEventDocs.nested.test.js` — nested `$ref`-based `oneOf`
  - `generateEventDocs.anchor.test.js` — inline `oneOf` with `$anchor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)