### PR TITLE
feat(docs): add edit links to overview and intro pages

### DIFF
--- a/demo/docs/00-index.mdx
+++ b/demo/docs/00-index.mdx
@@ -3,6 +3,7 @@ id: intro
 title: Welcome to Tracking Docs
 sidebar_label: Introduction
 slug: /
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/00-index.mdx
 ---
 
 import Tabs from '@theme/Tabs';

--- a/demo/docs/event-reference/05-root-choice-event/index.mdx
+++ b/demo/docs/event-reference/05-root-choice-event/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Root Choice Event
 description: "An example event that has oneOf at the root level."
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/events/root-choice-event.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/demo/docs/event-reference/index.mdx
+++ b/demo/docs/event-reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Event Reference
 description: "A dataLayer event for GTM"
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/next/event-reference.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/demo/versioned_docs/version-1.1.1/00-index.mdx
+++ b/demo/versioned_docs/version-1.1.1/00-index.mdx
@@ -3,6 +3,7 @@ id: intro
 title: Welcome to Tracking Docs
 sidebar_label: Introduction
 slug: /
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/docs/00-index.mdx
 ---
 
 import Tabs from '@theme/Tabs';

--- a/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/index.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/05-root-choice-event/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Root Choice Event
 description: "An example event that has oneOf at the root level."
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/events/root-choice-event.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/demo/versioned_docs/version-1.2.0/event-reference/index.mdx
+++ b/demo/versioned_docs/version-1.2.0/event-reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Event Reference
 description: "A dataLayer event for GTM"
+custom_edit_url: https://github.com/benedikt-buchert/tracking_docs/edit/main/demo/static/schemas/1.2.0/event-reference.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.anchor.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.anchor.test.js.snap
@@ -4,6 +4,7 @@ exports[`generateEventDocs (oneOf with $anchor) should generate documentation us
 "---
 title: Parent Event Anchor
 description: "This is a parent event with oneOf."
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_anchor__/static/schemas/parent-event-anchor.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.nested.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.nested.test.js.snap
@@ -4,6 +4,7 @@ exports[`generateEventDocs (nested oneOf) should generate nested documentation c
 "---
 title: Parent Event
 description: "undefined"
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/parent-event.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 
@@ -23,6 +24,7 @@ exports[`generateEventDocs (nested oneOf) should generate nested documentation c
 "---
 title: Child Event
 description: "undefined"
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures_nested__/static/schemas/child-event.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/__snapshots__/generateEventDocs.test.js.snap
@@ -91,6 +91,7 @@ exports[`generateEventDocs (non-versioned) should generate documentation correct
 "---
 title: Root Choice Event
 description: "An example event that has oneOf at the root level."
+custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 

--- a/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
@@ -72,6 +72,10 @@ async function generateOneOfDocs(
   outputDir,
   options,
 ) {
+  const { organizationName, projectName, siteDir } = options;
+  const baseEditUrl = `https://github.com/${organizationName}/${projectName}/edit/main`;
+  const editUrl = `${baseEditUrl}/${path.relative(path.join(siteDir, '..'), filePath)}`;
+
   const eventOutputDir = path.join(outputDir, eventName);
   createDir(eventOutputDir);
 
@@ -80,6 +84,7 @@ async function generateOneOfDocs(
   const indexPageContent = ChoiceIndexTemplate({
     schema,
     processedOptions: processed,
+    editUrl,
   });
   writeDoc(eventOutputDir, 'index.mdx', indexPageContent);
 
@@ -96,7 +101,7 @@ async function generateOneOfDocs(
       await generateOneOfDocs(
         prefixedSlug,
         processedSchema,
-        sourceFilePath || tempFilePath,
+        sourceFilePath || filePath,
         eventOutputDir,
         options,
       );

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/choice-index-template.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/choice-index-template.js
@@ -1,9 +1,10 @@
 export default function ChoiceIndexTemplate(data) {
-  const { schema, processedOptions } = data;
+  const { schema, processedOptions, editUrl } = data;
 
   return `---
 title: ${schema.title}
 description: "${schema.description}"
+custom_edit_url: ${editUrl}
 ---
 import SchemaJsonViewer from '@theme/SchemaJsonViewer';
 


### PR DESCRIPTION
## Summary

- Add `custom_edit_url` to the `ChoiceIndexTemplate` so oneOf index (overview) pages now have edit links pointing to the correct source schema file
- Fix the `root-choice-event/index.mdx` edit URL which previously pointed to `event-reference.json` instead of `root-choice-event.json` — this was caused by `generateOneOfDocs` falling back to `filePath` (the parent schema) instead of `sourceFilePath` (the resolved `$ref` target)
- Add `custom_edit_url` to the intro page (`docs/00-index.mdx` and `versioned_docs/version-1.1.1/00-index.mdx`)
- Update test snapshots to reflect corrected edit URLs for nested index pages

## Test plan

- [x] All 120 unit tests pass
- [x] Schema validation passes
- [x] ESLint passes
- [x] Verified `root-choice-event/index.mdx` now shows `custom_edit_url: .../events/root-choice-event.json`
- [x] Verified versioned `version-1.2.0/event-reference/05-root-choice-event/index.mdx` has the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)