### PR TITLE
fix: run tests before build in CI for faster feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Run tests
+        run: npm test
+
       - name: Generate docs
         run: npm run gen-docs
 
       - name: Run build
         run: npm run build
-
-      - name: Run tests
-        run: npm test
 
       - name: Validate Schemas
         run: npm run validate-schemas


### PR DESCRIPTION
## Summary

- Moves the test step before `gen-docs` and `build` in CI so failures are caught earlier without waiting for the full build to complete.

## Test plan
- [x] CI workflow order verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)