### PR TITLE
fix: remove dual-use signature from createValidator

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/validator.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/validator.test.js
@@ -12,7 +12,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 'test' });
 
     expect(result.valid).toBe(true);
@@ -30,7 +30,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 123 });
 
     expect(result.valid).toBe(false);
@@ -49,7 +49,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 'test' });
 
     expect(result.valid).toBe(true);
@@ -68,7 +68,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 'test' });
 
     expect(result.valid).toBe(true);
@@ -87,7 +87,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 'test' });
 
     expect(result.valid).toBe(true);
@@ -106,7 +106,7 @@ describe('createValidator', () => {
       required: ['name'],
     };
 
-    const validator = await createValidator(schema);
+    const validator = await createValidator([], schema);
     const result = validator({ name: 'test' });
 
     expect(result.valid).toBe(true);

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/validator.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/validator.js
@@ -71,10 +71,6 @@ function createAjvInstance(schemas, mainSchema, schemaPath) {
  * @returns {function(object): {valid: boolean, errors: object[]}} A function that takes data and returns a validation result.
  */
 export async function createValidator(schemas, mainSchema, schemaPath) {
-  if (!mainSchema) {
-    mainSchema = schemas;
-    schemas = [mainSchema];
-  }
   const ajv = createAjvInstance(schemas, mainSchema, schemaPath);
 
   let validate;


### PR DESCRIPTION
## Summary

- Removes the single-argument fallback in `createValidator` where passing only a schema would cause it to reassign `mainSchema = schemas`. Callers must now always pass `(schemas, mainSchema)` explicitly, making the API unambiguous.
- Updates all test call sites to pass `([], schema)` instead of `(schema)`.

## Test plan
- [x] All existing validator tests pass with updated call signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)