### PR TITLE
fix: remove unnecessary temp file I/O from generateOneOfDocs

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
@@ -96,8 +96,6 @@ async function generateOneOfDocs(
     const prefixedSlug = `${(index + 1).toString().padStart(2, '0')}-${slug}`;
 
     if (subChoiceType) {
-      const tempFilePath = path.join(eventOutputDir, `${slug}.json`);
-      fs.writeFileSync(tempFilePath, JSON.stringify(processedSchema, null, 2));
       await generateOneOfDocs(
         prefixedSlug,
         processedSchema,
@@ -105,12 +103,9 @@ async function generateOneOfDocs(
         eventOutputDir,
         options,
       );
-      fs.unlinkSync(tempFilePath);
     } else {
-      const tempFilePath = path.join(eventOutputDir, `${prefixedSlug}.json`);
-      fs.writeFileSync(tempFilePath, JSON.stringify(processedSchema, null, 2));
       await generateAndWriteDoc(
-        tempFilePath,
+        `${prefixedSlug}.json`,
         processedSchema,
         slug,
         eventOutputDir,
@@ -118,7 +113,6 @@ async function generateOneOfDocs(
         processedSchema,
         sourceFilePath || filePath,
       );
-      fs.unlinkSync(tempFilePath);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes `writeFileSync`/`unlinkSync` calls in `generateOneOfDocs` that were writing and immediately deleting temporary JSON files for each schema option. The schema data is already in memory and passed directly, so the temp file round-trip was unnecessary.

## Test plan
- [x] All existing generateEventDocs tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)