### PR TITLE
fix: rename loop variable to avoid shadowing function param

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/update-schema-ids.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/update-schema-ids.js
@@ -28,8 +28,8 @@ export default function updateSchemaIds(siteDir, url, version = null) {
     ? [version]
     : JSON.parse(fs.readFileSync(versionsJsonPath, 'utf8'));
 
-  for (const version of versions) {
-    const schemaDir = path.join(siteDir, 'static/schemas', version);
+  for (const v of versions) {
+    const schemaDir = path.join(siteDir, 'static/schemas', v);
     if (!fs.existsSync(schemaDir)) {
       continue;
     }
@@ -41,7 +41,7 @@ export default function updateSchemaIds(siteDir, url, version = null) {
       const relativePath = path.relative(path.join(siteDir, 'static'), file);
       schema.$id = `${baseUrl}/${relativePath.replace(/\\/g, '/')}`;
       fs.writeFileSync(file, JSON.stringify(schema, null, 2));
-      console.log(`Updated $id for ${file} in version ${version}`);
+      console.log(`Updated $id for ${file} in version ${v}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Renames the `version` loop variable in `updateSchemaIds` to `v` to avoid shadowing the `version` function parameter, preventing a subtle bug where the outer `version` param would be inaccessible inside the loop.

## Test plan
- [x] All existing update-schema-ids tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)