### PR TITLE
feat(issue-52): add x-tracking-targets contract and validation

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/trackingTargets.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/trackingTargets.test.js
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_TRACKING_TARGET,
+  resolveTrackingTargets,
+} from '../../helpers/trackingTargets';
+
+describe('trackingTargets', () => {
+  it('returns the configured targets when valid', () => {
+    const schema = {
+      'x-tracking-targets': ['web-datalayer-js', 'android-firebase-java-sdk'],
+    };
+
+    const result = resolveTrackingTargets(schema, { schemaFile: 'event.json' });
+    expect(result).toEqual({
+      targets: ['web-datalayer-js', 'android-firebase-java-sdk'],
+      warning: null,
+      errors: [],
+    });
+  });
+
+  it('falls back to default target when key is missing', () => {
+    const result = resolveTrackingTargets(
+      {},
+      { schemaFile: 'event.json', isQuiet: false },
+    );
+
+    expect(result.targets).toEqual([DEFAULT_TRACKING_TARGET]);
+    expect(result.errors).toEqual([]);
+    expect(result.warning).toContain(DEFAULT_TRACKING_TARGET);
+  });
+
+  it('returns an error for unknown targets', () => {
+    const schema = {
+      'x-tracking-targets': ['web-not-supported-js'],
+    };
+
+    const result = resolveTrackingTargets(schema, { schemaFile: 'event.json' });
+
+    expect(result.targets).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('web-not-supported-js');
+  });
+});

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
@@ -10,13 +10,16 @@ import validateSchemas from '../validateSchemas';
 describe('validateSchemas', () => {
   let tmpDir;
   let consoleErrorSpy;
-  let consoleLogSpy;
+  let consoleWarnSpy;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'schema-test-'));
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -49,5 +52,54 @@ describe('validateSchemas', () => {
     );
     const result = await validateSchemas(schemaDir);
     expect(result).toBe(false);
+  });
+
+  it('should warn and fallback to default target when x-tracking-targets is missing', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir);
+    expect(result).toBe(true);
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy.mock.calls[0][0]).toContain('web-datalayer-js');
+  });
+
+  it('should fail when x-tracking-targets has an unsupported target', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        'x-tracking-targets': ['web-not-supported-js'],
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir);
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleErrorSpy.mock.calls[0][0]).toContain('x-tracking-targets');
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/trackingTargets.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/trackingTargets.js
@@ -1,0 +1,73 @@
+export const DEFAULT_TRACKING_TARGET = 'web-datalayer-js';
+
+export const SUPPORTED_TRACKING_TARGETS = [
+  DEFAULT_TRACKING_TARGET,
+  'android-firebase-kotlin-sdk',
+  'android-firebase-java-sdk',
+  'ios-firebase-swift-sdk',
+  'ios-firebase-objc-sdk',
+];
+
+const TARGET_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+){2,}$/;
+
+export function resolveTrackingTargets(
+  schema,
+  { schemaFile = 'schema', isQuiet = false } = {},
+) {
+  const configuredTargets = schema?.['x-tracking-targets'];
+
+  if (configuredTargets == null) {
+    const warning = isQuiet
+      ? null
+      : `Schema ${schemaFile} is missing x-tracking-targets. Falling back to "${DEFAULT_TRACKING_TARGET}".`;
+    return {
+      targets: [DEFAULT_TRACKING_TARGET],
+      warning,
+      errors: [],
+    };
+  }
+
+  if (
+    !Array.isArray(configuredTargets) ||
+    configuredTargets.length === 0 ||
+    configuredTargets.some((target) => typeof target !== 'string')
+  ) {
+    return {
+      targets: [],
+      warning: null,
+      errors: [
+        'x-tracking-targets must be a non-empty array of string target IDs.',
+      ],
+    };
+  }
+
+  const errors = [];
+  const unknownTargets = configuredTargets.filter(
+    (target) => !SUPPORTED_TRACKING_TARGETS.includes(target),
+  );
+
+  if (unknownTargets.length > 0) {
+    errors.push(
+      `x-tracking-targets contains unsupported target(s): ${unknownTargets.join(
+        ', ',
+      )}.`,
+    );
+  }
+
+  const badlyFormattedTargets = configuredTargets.filter(
+    (target) => !TARGET_ID_PATTERN.test(target),
+  );
+  if (badlyFormattedTargets.length > 0) {
+    errors.push(
+      `x-tracking-targets must use lowercase kebab-case IDs like "web-datalayer-js". Invalid value(s): ${badlyFormattedTargets.join(
+        ', ',
+      )}.`,
+    );
+  }
+
+  return {
+    targets: errors.length === 0 ? configuredTargets : [],
+    warning: null,
+    errors,
+  };
+}

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/validator.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/validator.js
@@ -49,6 +49,7 @@ function createAjvInstance(schemas, mainSchema, schemaPath) {
   addFormats(ajv);
   if (ajv.addKeyword) {
     ajv.addKeyword('x-gtm-clear');
+    ajv.addKeyword('x-tracking-targets');
   }
   ajvKeywords(ajv);
 

--- a/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import processSchema from './helpers/processSchema.js';
 import { schemaToExamples } from './helpers/schemaToExamples.js';
+import { resolveTrackingTargets } from './helpers/trackingTargets.js';
 
 const validateSingleSchema = async (filePath, schemaPath) => {
   const file = path.basename(filePath);
@@ -13,6 +14,20 @@ const validateSingleSchema = async (filePath, schemaPath) => {
     const mergedSchema = await processSchema(filePath);
     const exampleGroups = schemaToExamples(mergedSchema);
     const originalSchema = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    const trackingTargets = resolveTrackingTargets(originalSchema, {
+      schemaFile: file,
+    });
+
+    if (trackingTargets.warning) {
+      console.warn(trackingTargets.warning);
+    }
+    if (trackingTargets.errors.length > 0) {
+      trackingTargets.errors.forEach((error) =>
+        errors.push(`x Schema ${file} ${error}`),
+      );
+      return { allValid: false, errors };
+    }
+
     const validate = await createValidator([], originalSchema, schemaPath);
 
     if (exampleGroups.length === 0) {


### PR DESCRIPTION
Closes #52

## Summary
- adds a central tracking target contract helper with:
  - default fallback target: `web-datalayer-js`
  - supported target registry for initial rollout
  - validation for shape, allowed IDs, and kebab-case target format
- validates `x-tracking-targets` during schema validation
- adds a non-blocking warning when fallback is used (missing `x-tracking-targets`)
- registers `x-tracking-targets` as custom AJV keyword

## TDD
- red: added failing tests for fallback warning + invalid target rejection + helper behavior
- green: implemented helper and validation wiring

## Tests
- targeted:
  - `npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/trackingTargets.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js`
- full:
  - `npm test -- --runInBand`
