### PR TITLE
Fix conditional branch rendering for required-only if/then/else

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/exampleModel.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/exampleModel.test.js
@@ -54,6 +54,53 @@ describe('buildExampleModel', () => {
     );
   });
 
+  it('builds distinct conditional examples for required-only branches', () => {
+    const model = buildExampleModel({
+      type: 'object',
+      properties: {
+        platform: {
+          type: 'string',
+          examples: ['ios'],
+        },
+        att_status: {
+          type: 'string',
+          examples: ['authorized'],
+        },
+        ad_personalization_enabled: {
+          type: 'boolean',
+          examples: [true],
+        },
+      },
+      if: {
+        properties: {
+          platform: {
+            const: 'ios',
+          },
+        },
+        required: ['platform'],
+      },
+      then: {
+        required: ['att_status'],
+      },
+      else: {
+        required: ['ad_personalization_enabled'],
+      },
+    });
+    const conditionalGroup = model.variantGroups.find(
+      (group) => group.property === 'conditional',
+    );
+
+    expect(conditionalGroup).toBeDefined();
+    expect(conditionalGroup.options[0].example).toEqual({
+      platform: 'ios',
+      att_status: 'authorized',
+    });
+    expect(conditionalGroup.options[1].example).toEqual({
+      platform: 'ios',
+      ad_personalization_enabled: true,
+    });
+  });
+
   it('uses configured dataLayerName in snippets', () => {
     const schema = {
       type: 'object',

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
@@ -278,6 +278,47 @@ describe('schemaToTableData', () => {
       expect(conditionalRow.branches[0].title).toBe('Then');
     });
 
+    it('materializes required-only branch rows from parent properties', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          platform: { type: 'string' },
+          att_status: { type: 'string' },
+          ad_personalization_enabled: { type: 'boolean' },
+        },
+        required: ['platform'],
+        if: {
+          properties: {
+            platform: { const: 'ios' },
+          },
+          required: ['platform'],
+        },
+        then: {
+          required: ['att_status'],
+        },
+        else: {
+          required: ['ad_personalization_enabled'],
+        },
+      };
+
+      const tableData = schemaToTableData(schema);
+      const conditionalRow = tableData.find((r) => r.type === 'conditional');
+      const thenBranch = conditionalRow.branches.find(
+        (b) => b.title === 'Then',
+      );
+      const elseBranch = conditionalRow.branches.find(
+        (b) => b.title === 'Else',
+      );
+
+      expect(thenBranch.rows).toHaveLength(1);
+      expect(thenBranch.rows[0].name).toBe('att_status');
+      expect(thenBranch.rows[0].required).toBe(true);
+
+      expect(elseBranch.rows).toHaveLength(1);
+      expect(elseBranch.rows[0].name).toBe('ad_personalization_enabled');
+      expect(elseBranch.rows[0].required).toBe(true);
+    });
+
     it('renders regular properties alongside conditional rows', () => {
       const tableData = schemaToTableData(conditionalEventSchema);
       const propRows = tableData.filter((r) => r.type === 'property');

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
@@ -63,18 +63,61 @@ const generateExampleForChoice = (rootSchema, path, option) => {
   }
 };
 
+const pruneSiblingConditionalProperties = (
+  mergedSchema,
+  activeBranchSchema,
+  inactiveBranchSchema,
+  baseRequired = [],
+) => {
+  const branchesOnlyAdjustRequired =
+    !activeBranchSchema?.properties && !inactiveBranchSchema?.properties;
+
+  if (
+    !mergedSchema?.properties ||
+    !branchesOnlyAdjustRequired ||
+    !Array.isArray(inactiveBranchSchema?.required)
+  ) {
+    return mergedSchema;
+  }
+
+  const activeRequired = new Set(activeBranchSchema?.required || []);
+  const protectedRequired = new Set(baseRequired);
+
+  inactiveBranchSchema.required.forEach((name) => {
+    if (activeRequired.has(name) || protectedRequired.has(name)) {
+      return;
+    }
+
+    delete mergedSchema.properties[name];
+    if (Array.isArray(mergedSchema.required)) {
+      mergedSchema.required = mergedSchema.required.filter(
+        (requiredName) => requiredName !== name,
+      );
+    }
+  });
+
+  return mergedSchema;
+};
+
 const generateConditionalExample = (rootSchema, path, branch) => {
   const schemaVariant = JSON.parse(JSON.stringify(rootSchema));
+  const siblingBranch = branch === 'then' ? 'else' : 'then';
 
   if (path.length === 0) {
     const branchSchema = schemaVariant[branch];
+    const siblingBranchSchema = schemaVariant[siblingBranch];
+    const baseRequired = schemaVariant.required || [];
     delete schemaVariant.if;
     delete schemaVariant.then;
     delete schemaVariant.else;
     if (branchSchema) {
-      return buildExampleFromSchema(
+      const merged = pruneSiblingConditionalProperties(
         mergeJsonSchema({ allOf: [schemaVariant, branchSchema] }),
+        branchSchema,
+        siblingBranchSchema,
+        baseRequired,
       );
+      return buildExampleFromSchema(merged);
     }
     return buildExampleFromSchema(schemaVariant);
   }
@@ -84,11 +127,18 @@ const generateConditionalExample = (rootSchema, path, branch) => {
     target = target[segment];
   }
   const branchSchema = target[branch];
+  const siblingBranchSchema = target[siblingBranch];
+  const baseRequired = target.required || [];
   delete target.if;
   delete target.then;
   delete target.else;
   if (branchSchema) {
-    const merged = mergeJsonSchema({ allOf: [target, branchSchema] });
+    const merged = pruneSiblingConditionalProperties(
+      mergeJsonSchema({ allOf: [target, branchSchema] }),
+      branchSchema,
+      siblingBranchSchema,
+      baseRequired,
+    );
     Object.keys(target).forEach((k) => delete target[k]);
     Object.assign(target, merged);
   }

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToTableData.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToTableData.js
@@ -11,6 +11,36 @@ function computeOwnBracket(level, parentGroupBrackets) {
   return { level, bracketIndex };
 }
 
+function materializeConditionalBranchSchema(branchSchema, parentSchema) {
+  if (
+    !branchSchema ||
+    branchSchema.properties ||
+    branchSchema.oneOf ||
+    branchSchema.anyOf ||
+    branchSchema.if ||
+    !Array.isArray(branchSchema.required) ||
+    !parentSchema?.properties
+  ) {
+    return branchSchema;
+  }
+
+  const branchProperties = Object.fromEntries(
+    branchSchema.required
+      .filter((name) => parentSchema.properties[name])
+      .map((name) => [name, parentSchema.properties[name]]),
+  );
+
+  if (Object.keys(branchProperties).length === 0) {
+    return branchSchema;
+  }
+
+  return {
+    ...branchSchema,
+    type: 'object',
+    properties: branchProperties,
+  };
+}
+
 function processOptions(
   choices,
   level,
@@ -144,11 +174,15 @@ export function schemaToTableData(
       // Then is NOT the last branch if Else exists — use innerContinuingLevels
       // to keep the parent line flowing. If Then IS the last branch, use original.
       const thenLevels = hasElse ? innerContinuingLevels : continuingLevels;
+      const thenSchema = materializeConditionalBranchSchema(
+        subSchema.then,
+        subSchema,
+      );
       branches.push({
         title: 'Then',
         description: subSchema.then.description,
         rows: schemaToTableData(
-          subSchema.then,
+          thenSchema,
           currentLevel,
           currentPath,
           thenLevels,
@@ -160,11 +194,15 @@ export function schemaToTableData(
     }
     if (hasElse) {
       // Else is always the last branch — use original continuingLevels
+      const elseSchema = materializeConditionalBranchSchema(
+        subSchema.else,
+        subSchema,
+      );
       branches.push({
         title: 'Else',
         description: subSchema.else.description,
         rows: schemaToTableData(
-          subSchema.else,
+          elseSchema,
           currentLevel,
           currentPath,
           continuingLevels,


### PR DESCRIPTION
## Summary
- fix Event Properties conditional rows for schemas where then/else only define required
- materialize branch properties from parent schema so Then/Else toggles render rows
- fix conditional example variants so required-only branches produce distinct payloads
- add regression tests for both table-data and example-model paths

## Validation
- pre-commit hooks ran: check:deps, jest, validate-schemas, eslint
- all tests passed (39 suites / 279 tests)

## Context
This fixes the checkout-options event page where selecting Then/Else showed no rows for the conditional block.
