### PR TITLE
Preserve falsy example values

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/example-helper.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/example-helper.test.js
@@ -34,6 +34,12 @@ describe('example-helper', () => {
       };
       expect(getExamples(schema)).toEqual(['example1']);
     });
+
+    it('preserves falsy "example" values', () => {
+      expect(getExamples({ example: false })).toEqual([false]);
+      expect(getExamples({ example: 0 })).toEqual([0]);
+      expect(getExamples({ example: '' })).toEqual(['']);
+    });
   });
 
   describe('getSingleExampleValue', () => {
@@ -66,6 +72,12 @@ describe('example-helper', () => {
         default: 'default-value',
       };
       expect(getSingleExampleValue(schema)).toBe('default-value');
+    });
+
+    it('returns falsy "example" values when present', () => {
+      expect(getSingleExampleValue({ example: false })).toBe(false);
+      expect(getSingleExampleValue({ example: 0 })).toBe(0);
+      expect(getSingleExampleValue({ example: '' })).toBe('');
     });
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
@@ -102,4 +102,54 @@ describe('validateSchemas', () => {
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(consoleErrorSpy.mock.calls[0][0]).toContain('x-tracking-targets');
   });
+
+  it('should treat falsy scalar examples as valid examples', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+          is_enabled: {
+            type: 'boolean',
+            example: false,
+          },
+          retry_count: {
+            type: 'integer',
+            example: 0,
+          },
+          note: {
+            type: 'string',
+            example: '',
+          },
+        },
+        required: ['event', 'is_enabled', 'retry_count', 'note'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir);
+    expect(result).toBe(true);
+  });
+
+  it('should allow a top-level falsy example value', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'flag.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'boolean',
+        example: false,
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir);
+    expect(result).toBe(true);
+  });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/example-helper.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/example-helper.js
@@ -5,7 +5,7 @@ export function getSingleExampleValue(propSchema) {
   if (propSchema.examples?.length > 0) {
     return propSchema.examples[0];
   }
-  if (propSchema.example) {
+  if (Object.prototype.hasOwnProperty.call(propSchema, 'example')) {
     return propSchema.example;
   }
   if (Object.prototype.hasOwnProperty.call(propSchema, 'default')) {
@@ -25,7 +25,7 @@ export function getExamples(propSchema) {
     examples.push(...propSchema.examples);
   }
 
-  if (propSchema.example) {
+  if (Object.prototype.hasOwnProperty.call(propSchema, 'example')) {
     if (!examples.includes(propSchema.example)) {
       examples.push(propSchema.example);
     }

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
@@ -151,10 +151,17 @@ export function schemaToExamples(rootSchema) {
 
   if (choicePoints.length === 0 && conditionalPoints.length === 0) {
     const example = buildExampleFromSchema(rootSchema);
-    if (example && Object.keys(example).length > 0) {
-      return [
-        { property: 'default', options: [{ title: 'Example', example }] },
-      ];
+    if (typeof example !== 'undefined') {
+      const shouldIncludeObjectExample =
+        typeof example !== 'object' ||
+        example === null ||
+        Object.keys(example).length > 0;
+
+      if (shouldIncludeObjectExample) {
+        return [
+          { property: 'default', options: [{ title: 'Example', example }] },
+        ];
+      }
     }
     return [];
   }

--- a/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
@@ -43,7 +43,7 @@ const validateSingleSchema = async (filePath, schemaPath) => {
         fileHasAnyExample = true;
         const { example, title } = option;
 
-        if (!example) {
+        if (typeof example === 'undefined') {
           errors.push(
             `x Schema ${file} (option: ${title}) does not produce a valid example.`,
           );


### PR DESCRIPTION
## Summary
- preserve falsy example values like false, 0, and empty string in example-helper
- keep top-level scalar examples in schemaToExamples instead of dropping them via truthiness checks
- validate falsy example values correctly in validateSchemas

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/example-helper.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
- npm test -- --runInBand
- git commit hooks (check:deps, test, validate-schemas, lint)
