### PR TITLE
Traverse GTM variables from schema branches

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
@@ -108,7 +108,55 @@ describe('getVariablesFromSchemas', () => {
           },
         },
       },
+      contact_method: {
+        type: 'object',
+        oneOf: [
+          {
+            title: 'Email Contact',
+            properties: {
+              email: {
+                type: 'string',
+                description: 'Email address.',
+              },
+            },
+          },
+          {
+            title: 'Phone Contact',
+            properties: {
+              phone_number: {
+                type: 'string',
+                description: 'Phone number.',
+              },
+            },
+          },
+        ],
+      },
+      platform: {
+        type: 'string',
+        description: 'Target platform.',
+      },
       timestamp: { type: 'number', description: 'Event timestamp.' },
+    },
+    if: {
+      properties: {
+        platform: { const: 'ios' },
+      },
+    },
+    then: {
+      properties: {
+        att_status: {
+          type: 'string',
+          description: 'App Tracking Transparency status.',
+        },
+      },
+    },
+    else: {
+      properties: {
+        ad_personalization_enabled: {
+          type: 'boolean',
+          description: 'Whether ad personalization is enabled.',
+        },
+      },
     },
   };
   const mobileEventSchema = {
@@ -160,7 +208,7 @@ describe('getVariablesFromSchemas', () => {
       expect.objectContaining({ name: 'timestamp' }),
     ]);
 
-    expect(result.length).toBe(8);
+    expect(result.length).toBe(14);
     expect(result).toEqual(expected);
   });
 
@@ -184,7 +232,26 @@ describe('getVariablesFromSchemas', () => {
     ];
 
     expect(result.map((r) => r.name)).toEqual(expect.arrayContaining(expected));
-    expect(result.length).toBe(expected.length);
+    expect(result.length).toBe(12);
+  });
+
+  it('should include variables from oneOf choices and conditional branches', async () => {
+    const bundledSchema = JSON.parse(JSON.stringify(complexEventSchema));
+    bundledSchema.properties.user_data.properties.addresses.items =
+      addressSchema;
+    RefParser.bundle.mockResolvedValue(bundledSchema);
+
+    const result = await gtmScript.getVariablesFromSchemas(SCHEMA_PATH, {});
+    const variableNames = result.map((variable) => variable.name);
+
+    expect(variableNames).toEqual(
+      expect.arrayContaining([
+        'contact_method.email',
+        'contact_method.phone_number',
+        'att_status',
+        'ad_personalization_enabled',
+      ]),
+    );
   });
 
   it('should ignore schemas that are not targeted to web-datalayer-js', async () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
@@ -88,7 +88,7 @@ function findJsonFiles(dir) {
 
 function parseSchema(schema, options, prefix = '') {
   if (!schema || !schema.properties) {
-    return [];
+    return parseBranchSchemas(schema, options, prefix);
   }
 
   let variables = [];
@@ -113,7 +113,37 @@ function parseSchema(schema, options, prefix = '') {
     } else if (property.type === 'object' && property.properties) {
       variables.push(...parseSchema(property, options, currentPath));
     }
+
+    variables.push(...parseBranchSchemas(property, options, currentPath));
   }
+
+  variables.push(...parseBranchSchemas(schema, options, prefix));
+  return variables;
+}
+
+function parseBranchSchemas(schema, options, prefix = '') {
+  if (!schema) {
+    return [];
+  }
+
+  const variables = [];
+  const choiceSchemas = [
+    ...(Array.isArray(schema.oneOf) ? schema.oneOf : []),
+    ...(Array.isArray(schema.anyOf) ? schema.anyOf : []),
+  ];
+
+  choiceSchemas.forEach((choiceSchema) => {
+    variables.push(...parseSchema(choiceSchema, options, prefix));
+  });
+
+  if (schema.then) {
+    variables.push(...parseSchema(schema.then, options, prefix));
+  }
+
+  if (schema.else) {
+    variables.push(...parseSchema(schema.else, options, prefix));
+  }
+
   return variables;
 }
 


### PR DESCRIPTION
## Summary
- teach sync-gtm to traverse oneOf/anyOf branch schemas when collecting GTM variable names
- teach sync-gtm to traverse then/else conditional branches as part of variable discovery
- add regression coverage for branch-derived variables while preserving existing top-level paths

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
- npm test -- --runInBand
- git commit hooks (check:deps, test, validate-schemas, lint)
