### PR TITLE
Use unique tooltip ids for schema keywords

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertyRow.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertyRow.test.js
@@ -275,13 +275,15 @@ describe('PropertyRow', () => {
     expect(keyword).not.toHaveAttribute('title');
     expect(keyword).toHaveAttribute(
       'aria-describedby',
-      'schema-keyword-help-additionalProperties',
+      'schema-keyword-help-user_properties-additionalProperties',
     );
     expect(
       container.querySelector('.property-keyword-tooltip'),
     ).toBeInTheDocument();
     expect(
-      container.querySelector('#schema-keyword-help-additionalProperties'),
+      container.querySelector(
+        '#schema-keyword-help-user_properties-additionalProperties',
+      ),
     ).toBeInTheDocument();
     expect(
       getByText(
@@ -323,11 +325,11 @@ describe('PropertyRow', () => {
     ).toBeInTheDocument();
     expect(keyword).toHaveAttribute(
       'aria-describedby',
-      'schema-keyword-help-patternProperties /^custom_/',
+      'schema-keyword-help-attributes-patternProperties___custom__',
     );
     expect(
       container.ownerDocument.getElementById(
-        'schema-keyword-help-patternProperties /^custom_/',
+        'schema-keyword-help-attributes-patternProperties___custom__',
       ),
     ).toBeInTheDocument();
     expect(
@@ -336,6 +338,48 @@ describe('PropertyRow', () => {
       ),
     ).toBeInTheDocument();
     expect(container.querySelector('.is-last')).toBeInTheDocument();
+  });
+
+  it('uses unique tooltip ids for repeated schema keyword rows', () => {
+    const firstRow = {
+      name: 'additionalProperties',
+      level: 1,
+      required: false,
+      propertyType: 'string',
+      description: 'User property values.',
+      examples: ['beta_tester'],
+      constraints: [],
+      path: ['user_properties', 'additionalProperties'],
+      hasChildren: false,
+      containerType: null,
+      continuingLevels: [],
+      isSchemaKeywordRow: true,
+      keepConnectorOpen: false,
+    };
+    const secondRow = {
+      ...firstRow,
+      path: ['metadata', 'additionalProperties'],
+      description: 'Metadata values.',
+    };
+
+    const { container, getAllByText } = render(
+      <table>
+        <tbody>
+          <PropertyRow row={firstRow} isLastInGroup={true} />
+          <PropertyRow row={secondRow} isLastInGroup={true} />
+        </tbody>
+      </table>,
+    );
+
+    const keywords = getAllByText('additionalProperties');
+    const firstTooltipId = keywords[0].getAttribute('aria-describedby');
+    const secondTooltipId = keywords[1].getAttribute('aria-describedby');
+
+    expect(firstTooltipId).toBeTruthy();
+    expect(secondTooltipId).toBeTruthy();
+    expect(firstTooltipId).not.toBe(secondTooltipId);
+    expect(container.querySelector(`#${firstTooltipId}`)).toBeInTheDocument();
+    expect(container.querySelector(`#${secondTooltipId}`)).toBeInTheDocument();
   });
 
   describe('hierarchical lines feature', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/components/PropertyRow.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/PropertyRow.js
@@ -58,6 +58,15 @@ function splitKeywordLabel(name) {
   };
 }
 
+function buildKeywordHelpId(name, rowPath) {
+  if (!rowPath || rowPath.length === 0) {
+    return `schema-keyword-help-${name}`;
+  }
+
+  const normalizedPath = rowPath.join('-').replace(/[^a-zA-Z0-9_-]/g, '_');
+  return `schema-keyword-help-${normalizedPath}`;
+}
+
 /**
  * Renders a single property row in the schema table.
  * All data is passed in via the `row` prop, which comes from `tableData`.
@@ -158,7 +167,7 @@ export default function PropertyRow({
     : name;
   const keywordHelpText = KEYWORD_HELP_TEXT[keywordHelpKey];
   const keywordHelpId = keywordHelpText
-    ? `schema-keyword-help-${name}`
+    ? buildKeywordHelpId(name, row.path)
     : undefined;
   const zebraClassName =
     stripeIndex === undefined


### PR DESCRIPTION
## Summary
- derive schema keyword tooltip ids from the row path instead of the keyword label alone
- prevent duplicate DOM ids when multiple additionalProperties or patternProperties rows appear on the same page
- add a regression test for repeated schema keyword rows and update existing tooltip id assertions

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertyRow.test.js
- npm test -- --runInBand
- git commit hooks (check:deps, test, validate-schemas, lint)
