### PR TITLE
Refactor shared schema traversal

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaTraversal.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaTraversal.test.js
@@ -1,0 +1,110 @@
+const {
+  visitSchemaNodes,
+  visitSchemaPropertyEntries,
+} = require('../../helpers/schemaTraversal.cjs');
+
+describe('schemaTraversal', () => {
+  it('visits nested choice and conditional schema nodes', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payment_method: {
+          oneOf: [
+            {
+              properties: {
+                card_number: { type: 'string' },
+              },
+            },
+          ],
+        },
+      },
+      if: {
+        properties: {
+          platform: { const: 'ios' },
+        },
+      },
+      then: {
+        properties: {
+          att_status: { type: 'string' },
+        },
+      },
+    };
+
+    const visitedPaths = [];
+    visitSchemaNodes(schema, (_node, context) => {
+      visitedPaths.push(context.path.join('.'));
+    });
+
+    expect(visitedPaths).toEqual(
+      expect.arrayContaining([
+        '',
+        'properties.payment_method',
+        'properties.payment_method.oneOf.0',
+        'properties.payment_method.oneOf.0.properties.card_number',
+        'if',
+        'then',
+        'then.properties.att_status',
+      ]),
+    );
+  });
+
+  it('collects property entries through object, array, choice, and conditional branches', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        event: { type: 'string' },
+        items: {
+          type: 'array',
+          items: {
+            properties: {
+              sku: { type: 'string' },
+            },
+          },
+        },
+        contact_method: {
+          type: 'object',
+          oneOf: [
+            {
+              properties: {
+                email: { type: 'string' },
+              },
+            },
+            {
+              properties: {
+                phone_number: { type: 'string' },
+              },
+            },
+          ],
+        },
+      },
+      then: {
+        properties: {
+          att_status: { type: 'string' },
+        },
+      },
+      else: {
+        properties: {
+          ad_personalization_enabled: { type: 'boolean' },
+        },
+      },
+    };
+
+    const variableNames = [];
+    visitSchemaPropertyEntries(schema, (_property, context) => {
+      variableNames.push(context.name);
+    });
+
+    expect(variableNames).toEqual(
+      expect.arrayContaining([
+        'event',
+        'items',
+        'items.0.sku',
+        'contact_method',
+        'contact_method.email',
+        'contact_method.phone_number',
+        'att_status',
+        'ad_personalization_enabled',
+      ]),
+    );
+  });
+});

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaToExamples.js
@@ -1,44 +1,31 @@
 import buildExampleFromSchema from './buildExampleFromSchema';
 import { mergeSchema } from './mergeSchema.js';
+import traversalHelpers from './schemaTraversal.cjs';
 
-const findChoicePoints = (subSchema, path = []) => {
-  if (!subSchema) {
-    return [];
-  }
+const { visitSchemaNodes } = traversalHelpers;
 
-  const choiceType = subSchema.oneOf
-    ? 'oneOf'
-    : subSchema.anyOf
-      ? 'anyOf'
-      : null;
-  const currentChoice = choiceType ? [{ path, schema: subSchema }] : [];
+const findChoicePoints = (schema) => {
+  const choicePoints = [];
 
-  const nestedChoices = subSchema.properties
-    ? Object.entries(subSchema.properties).flatMap(([key, propSchema]) =>
-        findChoicePoints(propSchema, [...path, 'properties', key]),
-      )
-    : [];
+  visitSchemaNodes(schema, (subSchema, context) => {
+    if (subSchema.oneOf || subSchema.anyOf) {
+      choicePoints.push({ path: context.path, schema: subSchema });
+    }
+  });
 
-  return [...currentChoice, ...nestedChoices];
+  return choicePoints;
 };
 
-const findConditionalPoints = (subSchema, path = []) => {
-  if (!subSchema) {
-    return [];
-  }
+const findConditionalPoints = (schema) => {
+  const conditionalPoints = [];
 
-  const currentConditional =
-    subSchema.if && (subSchema.then || subSchema.else)
-      ? [{ path, schema: subSchema }]
-      : [];
+  visitSchemaNodes(schema, (subSchema, context) => {
+    if (subSchema.if && (subSchema.then || subSchema.else)) {
+      conditionalPoints.push({ path: context.path, schema: subSchema });
+    }
+  });
 
-  const nestedConditionals = subSchema.properties
-    ? Object.entries(subSchema.properties).flatMap(([key, propSchema]) =>
-        findConditionalPoints(propSchema, [...path, 'properties', key]),
-      )
-    : [];
-
-  return [...currentConditional, ...nestedConditionals];
+  return conditionalPoints;
 };
 
 const generateExampleForChoice = (rootSchema, path, option) => {

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaTraversal.cjs
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schemaTraversal.cjs
@@ -1,0 +1,148 @@
+function visitSchemaNodes(schema, visitor, path = []) {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  visitor(schema, { path });
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    Object.entries(schema.properties).forEach(([key, propertySchema]) => {
+      visitSchemaNodes(propertySchema, visitor, [...path, 'properties', key]);
+    });
+  }
+
+  if (schema.items && typeof schema.items === 'object') {
+    visitSchemaNodes(schema.items, visitor, [...path, 'items']);
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    schema.oneOf.forEach((optionSchema, index) => {
+      visitSchemaNodes(optionSchema, visitor, [...path, 'oneOf', index]);
+    });
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    schema.anyOf.forEach((optionSchema, index) => {
+      visitSchemaNodes(optionSchema, visitor, [...path, 'anyOf', index]);
+    });
+  }
+
+  if (schema.if && typeof schema.if === 'object') {
+    visitSchemaNodes(schema.if, visitor, [...path, 'if']);
+  }
+
+  if (schema.then && typeof schema.then === 'object') {
+    visitSchemaNodes(schema.then, visitor, [...path, 'then']);
+  }
+
+  if (schema.else && typeof schema.else === 'object') {
+    visitSchemaNodes(schema.else, visitor, [...path, 'else']);
+  }
+}
+
+function visitPropertyEntryBranches(
+  schema,
+  visitor,
+  { prefix = '', path = [], skipArraySubProperties = false } = {},
+) {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(schema.oneOf)) {
+    schema.oneOf.forEach((optionSchema, index) => {
+      visitSchemaPropertyEntries(optionSchema, visitor, {
+        prefix,
+        path: [...path, 'oneOf', index],
+        skipArraySubProperties,
+      });
+    });
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    schema.anyOf.forEach((optionSchema, index) => {
+      visitSchemaPropertyEntries(optionSchema, visitor, {
+        prefix,
+        path: [...path, 'anyOf', index],
+        skipArraySubProperties,
+      });
+    });
+  }
+
+  if (schema.then && typeof schema.then === 'object') {
+    visitSchemaPropertyEntries(schema.then, visitor, {
+      prefix,
+      path: [...path, 'then'],
+      skipArraySubProperties,
+    });
+  }
+
+  if (schema.else && typeof schema.else === 'object') {
+    visitSchemaPropertyEntries(schema.else, visitor, {
+      prefix,
+      path: [...path, 'else'],
+      skipArraySubProperties,
+    });
+  }
+}
+
+function visitSchemaPropertyEntries(
+  schema,
+  visitor,
+  { prefix = '', path = [], skipArraySubProperties = false } = {},
+) {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    Object.entries(schema.properties).forEach(([key, propertySchema]) => {
+      const currentName = prefix ? `${prefix}.${key}` : key;
+      const currentPath = [...path, 'properties', key];
+
+      visitor(propertySchema, {
+        key,
+        name: currentName,
+        path: currentPath,
+        parentSchema: schema,
+      });
+
+      if (propertySchema?.type === 'object' && propertySchema.properties) {
+        visitSchemaPropertyEntries(propertySchema, visitor, {
+          prefix: currentName,
+          path: currentPath,
+          skipArraySubProperties,
+        });
+      }
+
+      if (
+        propertySchema?.type === 'array' &&
+        propertySchema.items?.properties &&
+        !skipArraySubProperties
+      ) {
+        visitSchemaPropertyEntries(propertySchema.items, visitor, {
+          prefix: `${currentName}.0`,
+          path: [...currentPath, 'items'],
+          skipArraySubProperties,
+        });
+      }
+
+      visitPropertyEntryBranches(propertySchema, visitor, {
+        prefix: currentName,
+        path: currentPath,
+        skipArraySubProperties,
+      });
+    });
+  }
+
+  visitPropertyEntryBranches(schema, visitor, {
+    prefix,
+    path,
+    skipArraySubProperties,
+  });
+}
+
+module.exports = {
+  visitSchemaNodes,
+  visitSchemaPropertyEntries,
+};

--- a/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
@@ -3,6 +3,9 @@ const path = require('path');
 const { execSync } = require('child_process');
 const RefParser = require('@apidevtools/json-schema-ref-parser');
 const mergeAllOf = require('json-schema-merge-allof');
+const {
+  visitSchemaPropertyEntries,
+} = require('../helpers/schemaTraversal.cjs');
 
 const logger = {
   _isQuiet: false,
@@ -87,62 +90,22 @@ function findJsonFiles(dir) {
 }
 
 function parseSchema(schema, options, prefix = '') {
-  if (!schema || !schema.properties) {
-    return parseBranchSchemas(schema, options, prefix);
-  }
-
-  let variables = [];
-  for (const key in schema.properties) {
-    const property = schema.properties[key];
-    const currentPath = prefix ? `${prefix}.${key}` : key;
-    variables.push({
-      name: currentPath,
-      description: property.description,
-      type: property.type,
-    });
-    if (
-      property.type === 'array' &&
-      property.items &&
-      !options.skipArraySubProperties
-    ) {
-      if (property.items.properties) {
-        variables.push(
-          ...parseSchema(property.items, options, `${currentPath}.0`),
-        );
-      }
-    } else if (property.type === 'object' && property.properties) {
-      variables.push(...parseSchema(property, options, currentPath));
-    }
-
-    variables.push(...parseBranchSchemas(property, options, currentPath));
-  }
-
-  variables.push(...parseBranchSchemas(schema, options, prefix));
-  return variables;
-}
-
-function parseBranchSchemas(schema, options, prefix = '') {
-  if (!schema) {
-    return [];
-  }
-
   const variables = [];
-  const choiceSchemas = [
-    ...(Array.isArray(schema.oneOf) ? schema.oneOf : []),
-    ...(Array.isArray(schema.anyOf) ? schema.anyOf : []),
-  ];
 
-  choiceSchemas.forEach((choiceSchema) => {
-    variables.push(...parseSchema(choiceSchema, options, prefix));
-  });
-
-  if (schema.then) {
-    variables.push(...parseSchema(schema.then, options, prefix));
-  }
-
-  if (schema.else) {
-    variables.push(...parseSchema(schema.else, options, prefix));
-  }
+  visitSchemaPropertyEntries(
+    schema,
+    (property, context) => {
+      variables.push({
+        name: context.name,
+        description: property.description,
+        type: property.type,
+      });
+    },
+    {
+      prefix,
+      skipArraySubProperties: options.skipArraySubProperties,
+    },
+  );
 
   return variables;
 }


### PR DESCRIPTION
## Summary
- add a shared schema traversal helper for schema nodes and property entries
- reuse the shared traversal in schema example generation
- reuse the shared traversal in GTM variable extraction and cover it with direct helper tests

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaTraversal.test.js
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToExamples.test.js
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
- npm test -- --runInBand