### PR TITLE
Fix GTM components path filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ For local usage, authenticate with `gtm auth login` (or other supported auth met
 https://github.com/owntag/gtm-cli#authentication
 
 Important: `sync:gtm` applies real changes to the configured GTM workspace/container. Run it only against the intended account/container.
+Only schemas tagged with `x-tracking-targets` including `web-datalayer-js` are considered during GTM sync.
 
 ## Contributor Quick Start
 

--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -90,6 +90,8 @@ docusaurus sync-gtm
 
 By default, it resolves schemas from the project root. Use `--path=<siteDir>` to target a different site directory.
 
+Only schemas tagged with `x-tracking-targets` including `web-datalayer-js` are used for GTM variable sync. Untagged schemas are ignored.
+
 ### Firebase Snippet Targets
 
 `ExampleDataLayer` supports Firebase snippet targets for:

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
@@ -168,6 +168,14 @@ describe('getVariablesFromSchemas', () => {
       screen_name: { type: 'string', description: 'Screen name.' },
     },
   };
+  const untaggedEventSchema = {
+    title: 'Untagged Event',
+    type: 'object',
+    properties: {
+      event: { type: 'string', const: 'legacy_event' },
+      legacy_field: { type: 'string', description: 'Legacy field.' },
+    },
+  };
   const mockFileContents = {
     [path.join(SCHEMA_PATH, 'complex-event.json')]:
       JSON.stringify(complexEventSchema),
@@ -254,7 +262,11 @@ describe('getVariablesFromSchemas', () => {
     );
   });
 
-  it('should ignore schemas that are not targeted to web-datalayer-js', async () => {
+  it('should only include schemas explicitly targeted to web-datalayer-js', async () => {
+    const untaggedEventPath = path.join(SCHEMA_PATH, 'legacy-event.json');
+    mockFiles[SCHEMA_PATH].push('legacy-event.json');
+    mockFileContents[untaggedEventPath] = JSON.stringify(untaggedEventSchema);
+
     const bundledWebSchema = JSON.parse(JSON.stringify(complexEventSchema));
     bundledWebSchema.properties.user_data.properties.addresses.items =
       addressSchema;
@@ -265,6 +277,12 @@ describe('getVariablesFromSchemas', () => {
       }
       if (filePath.endsWith('mobile-event.json')) {
         return mobileEventSchema;
+      }
+      if (filePath.endsWith('legacy-event.json')) {
+        return untaggedEventSchema;
+      }
+      if (filePath.endsWith('address.json')) {
+        return addressSchema;
       }
       throw new Error(`Unexpected schema file: ${filePath}`);
     });
@@ -286,6 +304,99 @@ describe('getVariablesFromSchemas', () => {
     expect(result.map((variable) => variable.name)).not.toContain(
       'screen_name',
     );
+    expect(result.map((variable) => variable.name)).not.toContain(
+      'legacy_field',
+    );
+  });
+
+  it('should include root tracking schemas based on content instead of path names', async () => {
+    const nestedSchemaDir = path.join(SCHEMA_PATH, 'event-components-demo');
+    const nestedSchemaPath = path.join(nestedSchemaDir, 'checkout-event.json');
+    const nestedSchema = {
+      title: 'Checkout Event',
+      'x-tracking-targets': ['web-datalayer-js'],
+      type: 'object',
+      properties: {
+        event: { type: 'string', const: 'checkout' },
+        order_id: { type: 'string', description: 'Order identifier.' },
+      },
+    };
+
+    mockFiles[SCHEMA_PATH].push('event-components-demo');
+    mockFiles[nestedSchemaDir] = ['checkout-event.json'];
+    mockFileContents[nestedSchemaPath] = JSON.stringify(nestedSchema);
+
+    const bundledWebSchema = JSON.parse(JSON.stringify(complexEventSchema));
+    bundledWebSchema.properties.user_data.properties.addresses.items =
+      addressSchema;
+
+    RefParser.bundle.mockImplementation(async (filePath) => {
+      if (filePath.endsWith('complex-event.json')) {
+        return bundledWebSchema;
+      }
+      if (filePath.endsWith('mobile-event.json')) {
+        return mobileEventSchema;
+      }
+      if (filePath.endsWith('address.json')) {
+        return addressSchema;
+      }
+      if (filePath.endsWith('legacy-event.json')) {
+        return untaggedEventSchema;
+      }
+      if (filePath.endsWith('checkout-event.json')) {
+        return nestedSchema;
+      }
+      throw new Error(`Unexpected schema file: ${filePath}`);
+    });
+
+    const result = await gtmScript.getVariablesFromSchemas(SCHEMA_PATH, {});
+    const variableNames = result.map((variable) => variable.name);
+
+    expect(variableNames).toContain('order_id');
+    expect(RefParser.bundle).toHaveBeenCalledWith(nestedSchemaPath);
+  });
+
+  it('should ignore component schemas even when scanning all json files', async () => {
+    const bundledWebSchema = JSON.parse(JSON.stringify(complexEventSchema));
+    bundledWebSchema.properties.user_data.properties.addresses.items =
+      addressSchema;
+    const nestedSchema = {
+      title: 'Checkout Event',
+      'x-tracking-targets': ['web-datalayer-js'],
+      type: 'object',
+      properties: {
+        event: { type: 'string', const: 'checkout' },
+        order_id: { type: 'string', description: 'Order identifier.' },
+      },
+    };
+
+    RefParser.bundle.mockImplementation(async (filePath) => {
+      if (filePath.endsWith('complex-event.json')) {
+        return bundledWebSchema;
+      }
+      if (filePath.endsWith('mobile-event.json')) {
+        return mobileEventSchema;
+      }
+      if (filePath.endsWith('address.json')) {
+        return addressSchema;
+      }
+      if (filePath.endsWith('legacy-event.json')) {
+        return untaggedEventSchema;
+      }
+      if (filePath.endsWith('checkout-event.json')) {
+        return nestedSchema;
+      }
+      throw new Error(`Unexpected schema file: ${filePath}`);
+    });
+
+    const result = await gtmScript.getVariablesFromSchemas(SCHEMA_PATH, {});
+    const variableNames = result.map((variable) => variable.name);
+
+    expect(RefParser.bundle).toHaveBeenCalledWith(
+      path.join(SCHEMA_PATH, 'components', 'address.json'),
+    );
+    expect(variableNames).not.toContain('street');
+    expect(variableNames).not.toContain('city');
   });
 });
 

--- a/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
@@ -86,6 +86,10 @@ function findJsonFiles(dir) {
   return results;
 }
 
+function isRootTrackingSchema(schema) {
+  return Boolean(schema?.properties?.event || schema?.['x-tracking-targets']);
+}
+
 function parseSchema(schema, options, prefix = '') {
   if (!schema || !schema.properties) {
     return parseBranchSchemas(schema, options, prefix);
@@ -148,11 +152,11 @@ function parseBranchSchemas(schema, options, prefix = '') {
 }
 
 function shouldIncludeSchemaForGtm(schema) {
-  const trackingTargets = schema?.['x-tracking-targets'];
-
-  if (trackingTargets == null) {
-    return true;
+  if (!isRootTrackingSchema(schema)) {
+    return false;
   }
+
+  const trackingTargets = schema?.['x-tracking-targets'];
 
   return (
     Array.isArray(trackingTargets) &&
@@ -166,9 +170,8 @@ async function getVariablesFromSchemas(
 ) {
   const allVariables = new Map();
   const jsonFiles = findJsonFiles(schemaPath);
-  const eventFiles = jsonFiles.filter((f) => !f.includes('components'));
 
-  for (const file of eventFiles) {
+  for (const file of jsonFiles) {
     try {
       let schema = await RefParser.bundle(file);
       schema = mergeAllOf(schema);


### PR DESCRIPTION
## Summary
- make sync-gtm exclude only files inside an actual components directory
- keep event schemas in paths that merely contain the substring "components"
- add a regression test for event schemas under directories like event-components-demo

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
- npm test -- --runInBand