### PR TITLE
Skip non-web schemas before GTM merge

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
@@ -168,6 +168,31 @@ describe('getVariablesFromSchemas', () => {
       screen_name: { type: 'string', description: 'Screen name.' },
     },
   };
+  const mobileConditionalSchema = {
+    title: 'Mobile Conditional Event',
+    'x-tracking-targets': ['android-firebase-kotlin-sdk'],
+    type: 'object',
+    allOf: [
+      {
+        if: {
+          properties: {
+            mobile_platform_hint: { const: 'ios' },
+          },
+          required: ['mobile_platform_hint'],
+        },
+        then: {
+          required: ['att_status'],
+        },
+        else: {
+          required: ['ad_personalization_enabled'],
+        },
+      },
+    ],
+    properties: {
+      event: { type: 'string', const: 'screen_view' },
+      mobile_platform_hint: { type: 'string' },
+    },
+  };
   const untaggedEventSchema = {
     title: 'Untagged Event',
     type: 'object',
@@ -306,6 +331,52 @@ describe('getVariablesFromSchemas', () => {
     );
     expect(result.map((variable) => variable.name)).not.toContain(
       'legacy_field',
+    );
+  });
+
+  it('should skip non-web schemas before mergeAllOf can fail on unsupported keywords', async () => {
+    const mobileConditionalPath = path.join(
+      SCHEMA_PATH,
+      'mobile-conditional-event.json',
+    );
+    mockFiles[SCHEMA_PATH].push('mobile-conditional-event.json');
+    mockFileContents[mobileConditionalPath] = JSON.stringify(
+      mobileConditionalSchema,
+    );
+
+    const bundledWebSchema = JSON.parse(JSON.stringify(complexEventSchema));
+    bundledWebSchema.properties.user_data.properties.addresses.items =
+      addressSchema;
+    const loggerErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    RefParser.bundle.mockImplementation(async (filePath) => {
+      if (filePath.endsWith('complex-event.json')) {
+        return bundledWebSchema;
+      }
+      if (filePath.endsWith('mobile-event.json')) {
+        return mobileEventSchema;
+      }
+      if (filePath.endsWith('mobile-conditional-event.json')) {
+        return mobileConditionalSchema;
+      }
+      if (filePath.endsWith('address.json')) {
+        return addressSchema;
+      }
+      throw new Error(`Unexpected schema file: ${filePath}`);
+    });
+
+    const result = await gtmScript.getVariablesFromSchemas(SCHEMA_PATH, {});
+
+    expect(result.map((variable) => variable.name)).not.toContain(
+      'mobile_platform_hint',
+    );
+    expect(loggerErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Error processing schema ${mobileConditionalPath}`,
+      ),
+      expect.any(Error),
     );
   });
 

--- a/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
@@ -137,10 +137,10 @@ async function getVariablesFromSchemas(
   for (const file of jsonFiles) {
     try {
       let schema = await RefParser.bundle(file);
-      schema = mergeAllOf(schema);
       if (!shouldIncludeSchemaForGtm(schema)) {
         continue;
       }
+      schema = mergeAllOf(schema);
       const fileVariables = parseSchema(schema, { skipArraySubProperties });
       for (const variable of fileVariables) {
         if (!allVariables.has(variable.name)) {


### PR DESCRIPTION
## Summary
- skip non-web schemas before running  in GTM sync
- add a regression test for mobile-only schemas with  and 
- prevent noisy live-sync errors from non-web schemas that were going to be excluded anyway

## Why
A live  run hit  errors on mobile-only schemas containing conditionals. The sync still completed, but it was processing schemas outside GTM scope before filtering.

## Testing
- npm test -- --runInBand packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
- npm test -- --runInBand
- npm run sync:gtm
