### PR TITLE
feat: make all web events a dataLayer tracking target

### DIFF
--- a/demo/static/schemas/1.3.0/web/add-to-cart-event.json
+++ b/demo/static/schemas/1.3.0/web/add-to-cart-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
   "title": "Add to Cart Event",
   "description": "An add_to_cart event fires when a user adds one or more items to their shopping cart. Based on Google Analytics 4 ecommerce event specifications.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/1.3.0/web/battle-test-event.json
+++ b/demo/static/schemas/1.3.0/web/battle-test-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
   "title": "Battle Test Event",
   "description": "A stress-test event exercising every nesting combination: oneOf/anyOf inside if/then/else, if/then/else inside oneOf/anyOf branches, nested conditionals inside conditionals, array items with all combos, and deeply nested objects.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "required": ["event", "user", "items", "payment", "fulfillment"],
   "properties": {

--- a/demo/static/schemas/1.3.0/web/choice-event.json
+++ b/demo/static/schemas/1.3.0/web/choice-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
   "title": "Choice Event",
   "description": "An example event that uses oneOf and anyOf.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/1.3.0/web/conditional-event.json
+++ b/demo/static/schemas/1.3.0/web/conditional-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
   "title": "Conditional Event",
   "description": "An event demonstrating if/then/else conditional properties. The postal code format depends on the selected country.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/1.3.0/web/nested-conditional-event.json
+++ b/demo/static/schemas/1.3.0/web/nested-conditional-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
   "title": "Nested Conditional Event",
   "description": "An event demonstrating if/then/else conditional properties nested inside a property. The shipping details depend on the selected method.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/1.3.0/web/root-any-of-event.json
+++ b/demo/static/schemas/1.3.0/web/root-any-of-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
   "title": "Root AnyOf Event",
   "description": "An example event that has anyOf at the root level.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/1.3.0/web/root-choice-event.json
+++ b/demo/static/schemas/1.3.0/web/root-choice-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
   "title": "Root Choice Event",
   "description": "An example event that has oneOf at the root level.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "allOf": [
     {
       "type": "object",

--- a/demo/static/schemas/next/web/add-to-cart-event.json
+++ b/demo/static/schemas/next/web/add-to-cart-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
   "title": "Add to Cart Event",
   "description": "An add_to_cart event fires when a user adds one or more items to their shopping cart. Based on Google Analytics 4 ecommerce event specifications.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/next/web/battle-test-event.json
+++ b/demo/static/schemas/next/web/battle-test-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
   "title": "Battle Test Event",
   "description": "A stress-test event exercising every nesting combination: oneOf/anyOf inside if/then/else, if/then/else inside oneOf/anyOf branches, nested conditionals inside conditionals, array items with all combos, and deeply nested objects.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "required": ["event", "user", "items", "payment", "fulfillment"],
   "properties": {

--- a/demo/static/schemas/next/web/choice-event.json
+++ b/demo/static/schemas/next/web/choice-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
   "title": "Choice Event",
   "description": "An example event that uses oneOf and anyOf.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/next/web/conditional-event.json
+++ b/demo/static/schemas/next/web/conditional-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
   "title": "Conditional Event",
   "description": "An event demonstrating if/then/else conditional properties. The postal code format depends on the selected country.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/next/web/nested-conditional-event.json
+++ b/demo/static/schemas/next/web/nested-conditional-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
   "title": "Nested Conditional Event",
   "description": "An event demonstrating if/then/else conditional properties nested inside a property. The shipping details depend on the selected method.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/next/web/root-any-of-event.json
+++ b/demo/static/schemas/next/web/root-any-of-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
   "title": "Root AnyOf Event",
   "description": "An example event that has anyOf at the root level.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "type": "object",
   "properties": {
     "$schema": {

--- a/demo/static/schemas/next/web/root-choice-event.json
+++ b/demo/static/schemas/next/web/root-choice-event.json
@@ -3,6 +3,7 @@
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
   "title": "Root Choice Event",
   "description": "An example event that has oneOf at the root level.",
+  "x-tracking-targets": ["web-datalayer-js"],
   "allOf": [
     {
       "type": "object",


### PR DESCRIPTION
## Summary

- Adds `x-tracking-targets` with `web-datalayer-js` to all web event schemas in both `next/` and `1.3.0/` that were missing the explicit target declaration

## Changed files

14 schema files across `demo/static/schemas/next/web/` and `demo/static/schemas/1.3.0/web/`:
`add-to-cart-event`, `battle-test-event`, `choice-event`, `conditional-event`, `nested-conditional-event`, `root-any-of-event`, `root-choice-event`

## Test plan

- [ ] `npm run validate-schemas` passes
- [ ] `npm run lint` passes