### PR TITLE
Fix lint warnings: add missing descriptions to demo schema properties

### DIFF
--- a/demo/static/schemas/1.1.1/complex-event.json
+++ b/demo/static/schemas/1.1.1/complex-event.json
@@ -67,14 +67,17 @@
             "properties": {
               "street": {
                 "type": "string",
+                "description": "The street address.",
                 "examples": ["123 Main St"]
               },
               "city": {
                 "type": "string",
+                "description": "The city name.",
                 "examples": ["New York"]
               },
               "zip": {
                 "type": "string",
+                "description": "The postal ZIP code.",
                 "examples": ["10001"]
               }
             }
@@ -139,10 +142,12 @@
       "properties": {
         "prop_a": {
           "type": "string",
+          "description": "First arbitrary string property.",
           "examples": ["some_value"]
         },
         "prop_b": {
           "type": "string",
+          "description": "Second arbitrary string property.",
           "examples": ["another_value"]
         }
       },
@@ -162,10 +167,12 @@
       "properties": {
         "credit_card": {
           "type": "number",
+          "description": "The credit card number.",
           "examples": [1234567890123456]
         },
         "billing_address": {
           "type": "string",
+          "description": "The billing address associated with the credit card.",
           "examples": ["123 Billing Address, Anytown, USA"]
         }
       },

--- a/demo/static/schemas/1.2.0/events/battle-test-event.json
+++ b/demo/static/schemas/1.2.0/events/battle-test-event.json
@@ -67,7 +67,11 @@
                 "type": "object",
                 "description": "Contact via email.",
                 "properties": {
-                  "channel": { "type": "string", "const": "email" },
+                  "channel": {
+                    "type": "string",
+                    "const": "email",
+                    "description": "The contact channel identifier."
+                  },
                   "email_address": {
                     "type": "string",
                     "format": "email",
@@ -82,7 +86,11 @@
                 "type": "object",
                 "description": "Contact via SMS.",
                 "properties": {
-                  "channel": { "type": "string", "const": "sms" },
+                  "channel": {
+                    "type": "string",
+                    "const": "sms",
+                    "description": "The contact channel identifier."
+                  },
                   "phone_number": {
                     "type": "string",
                     "description": "The user's phone number.",
@@ -228,7 +236,11 @@
                   "type": "object",
                   "description": "Regular parcel shipping.",
                   "properties": {
-                    "class": { "type": "string", "const": "standard_parcel" },
+                    "class": {
+                      "type": "string",
+                      "const": "standard_parcel",
+                      "description": "The shipping class identifier."
+                    },
                     "estimated_days": {
                       "type": "integer",
                       "description": "Estimated delivery days.",
@@ -243,7 +255,11 @@
                   "type": "object",
                   "description": "Heavy/oversized freight shipping.",
                   "properties": {
-                    "class": { "type": "string", "const": "freight" },
+                    "class": {
+                      "type": "string",
+                      "const": "freight",
+                      "description": "The shipping class identifier."
+                    },
                     "requires_signature": {
                       "type": "boolean",
                       "description": "Whether delivery requires a signature.",
@@ -298,7 +314,11 @@
           "title": "Credit Card",
           "description": "Payment by credit card — includes if/then/else based on card brand (if/then/else inside anyOf).",
           "properties": {
-            "method": { "type": "string", "const": "credit_card" },
+            "method": {
+              "type": "string",
+              "const": "credit_card",
+              "description": "The payment method identifier."
+            },
             "card_brand": {
               "type": "string",
               "description": "Card network.",
@@ -345,7 +365,11 @@
           "title": "Digital Wallet",
           "description": "Payment by digital wallet.",
           "properties": {
-            "method": { "type": "string", "const": "digital_wallet" },
+            "method": {
+              "type": "string",
+              "const": "digital_wallet",
+              "description": "The payment method identifier."
+            },
             "wallet_provider": {
               "description": "The wallet provider, either a known name or a custom string.",
               "oneOf": [
@@ -377,7 +401,11 @@
           "title": "Bank Transfer",
           "description": "Payment by bank transfer.",
           "properties": {
-            "method": { "type": "string", "const": "bank_transfer" },
+            "method": {
+              "type": "string",
+              "const": "bank_transfer",
+              "description": "The payment method identifier."
+            },
             "bank_name": {
               "type": "string",
               "description": "Name of the bank.",
@@ -412,7 +440,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "home_delivery"
+              "const": "home_delivery",
+              "description": "The fulfillment method identifier."
             },
             "address": {
               "type": "object",
@@ -486,7 +515,11 @@
           "title": "Store Pickup",
           "description": "In-store pickup.",
           "properties": {
-            "fulfillment_method": { "type": "string", "const": "store_pickup" },
+            "fulfillment_method": {
+              "type": "string",
+              "const": "store_pickup",
+              "description": "The fulfillment method identifier."
+            },
             "store_id": {
               "type": "string",
               "description": "ID of the pickup store.",
@@ -500,7 +533,11 @@
                   "type": "object",
                   "description": "A specific scheduled pickup time.",
                   "properties": {
-                    "slot_type": { "type": "string", "const": "scheduled" },
+                    "slot_type": {
+                      "type": "string",
+                      "const": "scheduled",
+                      "description": "The pickup slot type identifier."
+                    },
                     "datetime": {
                       "type": "string",
                       "format": "date-time",
@@ -515,7 +552,11 @@
                   "type": "object",
                   "description": "Pick up as soon as possible.",
                   "properties": {
-                    "slot_type": { "type": "string", "const": "asap" },
+                    "slot_type": {
+                      "type": "string",
+                      "const": "asap",
+                      "description": "The pickup slot type identifier."
+                    },
                     "estimated_ready_minutes": {
                       "type": "integer",
                       "description": "Estimated minutes until ready.",
@@ -534,7 +575,11 @@
           "title": "Digital Fulfillment",
           "description": "Purely digital delivery.",
           "properties": {
-            "fulfillment_method": { "type": "string", "const": "digital" },
+            "fulfillment_method": {
+              "type": "string",
+              "const": "digital",
+              "description": "The fulfillment method identifier."
+            },
             "delivery_email": {
               "type": "string",
               "format": "email",
@@ -554,7 +599,11 @@
           "type": "object",
           "description": "A percentage-based discount.",
           "properties": {
-            "type": { "type": "string", "const": "percentage" },
+            "type": {
+              "type": "string",
+              "const": "percentage",
+              "description": "The discount type identifier."
+            },
             "value": {
               "type": "number",
               "description": "Discount percentage (0-100).",
@@ -570,7 +619,11 @@
           "type": "object",
           "description": "A fixed-amount discount.",
           "properties": {
-            "type": { "type": "string", "const": "fixed" },
+            "type": {
+              "type": "string",
+              "const": "fixed",
+              "description": "The discount type identifier."
+            },
             "amount": {
               "type": "number",
               "description": "Discount amount in the transaction currency.",
@@ -601,7 +654,11 @@
               "description": "Event from a web browser, with if/then/else based on device type.",
               "required": ["platform", "device_type"],
               "properties": {
-                "platform": { "type": "string", "const": "web" },
+                "platform": {
+                  "type": "string",
+                  "const": "web",
+                  "description": "The source platform identifier."
+                },
                 "device_type": {
                   "type": "string",
                   "description": "The type of device.",
@@ -655,7 +712,11 @@
               "description": "Event from a native app.",
               "required": ["platform", "app_version"],
               "properties": {
-                "platform": { "type": "string", "const": "app" },
+                "platform": {
+                  "type": "string",
+                  "const": "app",
+                  "description": "The source platform identifier."
+                },
                 "app_version": {
                   "type": "string",
                   "description": "Semantic version of the app.",
@@ -679,7 +740,10 @@
     "properties": {
       "payment": {
         "properties": {
-          "currency": { "const": "USD" }
+          "currency": {
+            "const": "USD",
+            "description": "ISO 4217 currency code."
+          }
         }
       }
     }

--- a/demo/static/schemas/1.2.0/events/choice-event.json
+++ b/demo/static/schemas/1.2.0/events/choice-event.json
@@ -12,7 +12,8 @@
     },
     "event": {
       "type": "string",
-      "const": "one_of_event"
+      "const": "one_of_event",
+      "description": "The event name."
     },
     "user_id": {
       "description": "The user's ID.",
@@ -41,15 +42,18 @@
           "properties": {
             "payment_type": {
               "type": "string",
+              "description": "The type of payment.",
               "enum": ["credit_card", "debit_card"],
               "examples": ["credit_card"]
             },
             "card_number": {
               "type": "string",
+              "description": "The card number.",
               "examples": ["1234-5678-9012-3456"]
             },
             "expiry_date": {
               "type": "string",
+              "description": "The card expiry date.",
               "examples": ["12/26"]
             }
           },
@@ -61,11 +65,13 @@
           "properties": {
             "payment_type": {
               "type": "string",
-              "const": "paypal"
+              "const": "paypal",
+              "description": "The type of payment."
             },
             "email": {
               "type": "string",
               "format": "email",
+              "description": "The PayPal account email address.",
               "examples": ["test@example.com"]
             }
           },

--- a/demo/static/schemas/1.2.0/events/complex-event.json
+++ b/demo/static/schemas/1.2.0/events/complex-event.json
@@ -68,14 +68,17 @@
             "properties": {
               "street": {
                 "type": "string",
+                "description": "The street address.",
                 "examples": ["123 Main St"]
               },
               "city": {
                 "type": "string",
+                "description": "The city name.",
                 "examples": ["New York"]
               },
               "zip": {
                 "type": "string",
+                "description": "The postal ZIP code.",
                 "examples": ["10001"]
               }
             }
@@ -140,10 +143,12 @@
       "properties": {
         "prop_a": {
           "type": "string",
+          "description": "First arbitrary string property.",
           "examples": ["some_value"]
         },
         "prop_b": {
           "type": "string",
+          "description": "Second arbitrary string property.",
           "examples": ["another_value"]
         }
       },
@@ -163,10 +168,12 @@
       "properties": {
         "credit_card": {
           "type": "number",
+          "description": "The credit card number.",
           "examples": [1234567890123456]
         },
         "billing_address": {
           "type": "string",
+          "description": "The billing address associated with the credit card.",
           "examples": ["123 Billing Address, Anytown, USA"]
         }
       },

--- a/demo/static/schemas/1.2.0/events/root-any-of-event.json
+++ b/demo/static/schemas/1.2.0/events/root-any-of-event.json
@@ -12,7 +12,8 @@
     },
     "event": {
       "type": "string",
-      "const": "any_of_event"
+      "const": "any_of_event",
+      "description": "The event name."
     }
   },
   "required": ["$schema", "event"],
@@ -23,6 +24,7 @@
       "properties": {
         "param_c": {
           "type": "string",
+          "description": "An optional string parameter for option C.",
           "examples": ["example_c"]
         }
       }
@@ -32,6 +34,7 @@
       "properties": {
         "param_d": {
           "type": "boolean",
+          "description": "An optional boolean parameter for option D.",
           "examples": [true]
         }
       }

--- a/demo/static/schemas/1.2.0/events/root-choice-event.json
+++ b/demo/static/schemas/1.2.0/events/root-choice-event.json
@@ -25,10 +25,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_a"
+              "const": "option_a",
+              "description": "The event name."
             },
             "param_a": {
               "type": "string",
+              "description": "A string parameter for option A.",
               "examples": ["example_a"]
             }
           }
@@ -40,10 +42,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_b"
+              "const": "option_b",
+              "description": "The event name."
             },
             "param_b": {
               "type": "integer",
+              "description": "An integer parameter for option B.",
               "examples": [123]
             }
           }

--- a/demo/static/schemas/1.3.0/web/battle-test-event.json
+++ b/demo/static/schemas/1.3.0/web/battle-test-event.json
@@ -74,7 +74,8 @@
                 "properties": {
                   "channel": {
                     "type": "string",
-                    "const": "email"
+                    "const": "email",
+                    "description": "The contact channel identifier."
                   },
                   "email_address": {
                     "type": "string",
@@ -92,7 +93,8 @@
                 "properties": {
                   "channel": {
                     "type": "string",
-                    "const": "sms"
+                    "const": "sms",
+                    "description": "The contact channel identifier."
                   },
                   "phone_number": {
                     "type": "string",
@@ -251,7 +253,8 @@
                   "properties": {
                     "class": {
                       "type": "string",
-                      "const": "standard_parcel"
+                      "const": "standard_parcel",
+                      "description": "The shipping class identifier."
                     },
                     "estimated_days": {
                       "type": "integer",
@@ -269,7 +272,8 @@
                   "properties": {
                     "class": {
                       "type": "string",
-                      "const": "freight"
+                      "const": "freight",
+                      "description": "The shipping class identifier."
                     },
                     "requires_signature": {
                       "type": "boolean",
@@ -327,7 +331,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "credit_card"
+              "const": "credit_card",
+              "description": "The payment method identifier."
             },
             "card_brand": {
               "type": "string",
@@ -381,7 +386,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "digital_wallet"
+              "const": "digital_wallet",
+              "description": "The payment method identifier."
             },
             "wallet_provider": {
               "description": "The wallet provider, either a known name or a custom string.",
@@ -416,7 +422,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "bank_transfer"
+              "const": "bank_transfer",
+              "description": "The payment method identifier."
             },
             "bank_name": {
               "type": "string",
@@ -452,7 +459,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "home_delivery"
+              "const": "home_delivery",
+              "description": "The fulfillment method identifier."
             },
             "address": {
               "type": "object",
@@ -534,7 +542,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "store_pickup"
+              "const": "store_pickup",
+              "description": "The fulfillment method identifier."
             },
             "store_id": {
               "type": "string",
@@ -551,7 +560,8 @@
                   "properties": {
                     "slot_type": {
                       "type": "string",
-                      "const": "scheduled"
+                      "const": "scheduled",
+                      "description": "The pickup slot type identifier."
                     },
                     "datetime": {
                       "type": "string",
@@ -569,7 +579,8 @@
                   "properties": {
                     "slot_type": {
                       "type": "string",
-                      "const": "asap"
+                      "const": "asap",
+                      "description": "The pickup slot type identifier."
                     },
                     "estimated_ready_minutes": {
                       "type": "integer",
@@ -591,7 +602,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "digital"
+              "const": "digital",
+              "description": "The fulfillment method identifier."
             },
             "delivery_email": {
               "type": "string",
@@ -614,7 +626,8 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "percentage"
+              "const": "percentage",
+              "description": "The discount type identifier."
             },
             "value": {
               "type": "number",
@@ -633,7 +646,8 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "fixed"
+              "const": "fixed",
+              "description": "The discount type identifier."
             },
             "amount": {
               "type": "number",
@@ -667,7 +681,8 @@
               "properties": {
                 "platform": {
                   "type": "string",
-                  "const": "web"
+                  "const": "web",
+                  "description": "The source platform identifier."
                 },
                 "device_type": {
                   "type": "string",
@@ -728,7 +743,8 @@
               "properties": {
                 "platform": {
                   "type": "string",
-                  "const": "app"
+                  "const": "app",
+                  "description": "The source platform identifier."
                 },
                 "app_version": {
                   "type": "string",
@@ -754,7 +770,8 @@
       "payment": {
         "properties": {
           "currency": {
-            "const": "USD"
+            "const": "USD",
+            "description": "ISO 4217 currency code."
           }
         }
       }
@@ -795,7 +812,8 @@
         "tax": {
           "properties": {
             "jurisdiction": {
-              "const": "CA"
+              "const": "CA",
+              "description": "Tax jurisdiction (state)."
             }
           }
         }

--- a/demo/static/schemas/1.3.0/web/choice-event.json
+++ b/demo/static/schemas/1.3.0/web/choice-event.json
@@ -13,7 +13,8 @@
     },
     "event": {
       "type": "string",
-      "const": "one_of_event"
+      "const": "one_of_event",
+      "description": "The event name."
     },
     "user_id": {
       "description": "The user's ID.",
@@ -42,15 +43,18 @@
           "properties": {
             "payment_type": {
               "type": "string",
+              "description": "The type of payment.",
               "enum": ["credit_card", "debit_card"],
               "examples": ["credit_card"]
             },
             "card_number": {
               "type": "string",
+              "description": "The card number.",
               "examples": ["1234-5678-9012-3456"]
             },
             "expiry_date": {
               "type": "string",
+              "description": "The card expiry date.",
               "examples": ["12/26"]
             }
           },
@@ -62,11 +66,13 @@
           "properties": {
             "payment_type": {
               "type": "string",
-              "const": "paypal"
+              "const": "paypal",
+              "description": "The type of payment."
             },
             "email": {
               "type": "string",
               "format": "email",
+              "description": "The PayPal account email address.",
               "examples": ["test@example.com"]
             }
           },

--- a/demo/static/schemas/1.3.0/web/complex-event.json
+++ b/demo/static/schemas/1.3.0/web/complex-event.json
@@ -82,14 +82,17 @@
             "properties": {
               "street": {
                 "type": "string",
+                "description": "The street address.",
                 "examples": ["123 Main St"]
               },
               "city": {
                 "type": "string",
+                "description": "The city name.",
                 "examples": ["New York"]
               },
               "zip": {
                 "type": "string",
+                "description": "The postal ZIP code.",
                 "examples": ["10001"]
               }
             }
@@ -154,10 +157,12 @@
       "properties": {
         "prop_a": {
           "type": "string",
+          "description": "First arbitrary string property.",
           "examples": ["some_value"]
         },
         "prop_b": {
           "type": "string",
+          "description": "Second arbitrary string property.",
           "examples": ["another_value"]
         }
       },
@@ -177,10 +182,12 @@
       "properties": {
         "credit_card": {
           "type": "number",
+          "description": "The credit card number.",
           "examples": [1234567890123456]
         },
         "billing_address": {
           "type": "string",
+          "description": "The billing address associated with the credit card.",
           "examples": ["123 Billing Address, Anytown, USA"]
         }
       },

--- a/demo/static/schemas/1.3.0/web/root-any-of-event.json
+++ b/demo/static/schemas/1.3.0/web/root-any-of-event.json
@@ -13,7 +13,8 @@
     },
     "event": {
       "type": "string",
-      "const": "any_of_event"
+      "const": "any_of_event",
+      "description": "The event name."
     }
   },
   "required": ["$schema", "event"],
@@ -24,6 +25,7 @@
       "properties": {
         "param_c": {
           "type": "string",
+          "description": "An optional string parameter for option C.",
           "examples": ["example_c"]
         }
       }
@@ -33,6 +35,7 @@
       "properties": {
         "param_d": {
           "type": "boolean",
+          "description": "An optional boolean parameter for option D.",
           "examples": [true]
         }
       }

--- a/demo/static/schemas/1.3.0/web/root-choice-event.json
+++ b/demo/static/schemas/1.3.0/web/root-choice-event.json
@@ -26,10 +26,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_a"
+              "const": "option_a",
+              "description": "The event name."
             },
             "param_a": {
               "type": "string",
+              "description": "A string parameter for option A.",
               "examples": ["example_a"]
             }
           }
@@ -41,10 +43,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_b"
+              "const": "option_b",
+              "description": "The event name."
             },
             "param_b": {
               "type": "integer",
+              "description": "An integer parameter for option B.",
               "examples": [123]
             }
           }

--- a/demo/static/schemas/next/web/battle-test-event.json
+++ b/demo/static/schemas/next/web/battle-test-event.json
@@ -74,7 +74,8 @@
                 "properties": {
                   "channel": {
                     "type": "string",
-                    "const": "email"
+                    "const": "email",
+                    "description": "The contact channel identifier."
                   },
                   "email_address": {
                     "type": "string",
@@ -92,7 +93,8 @@
                 "properties": {
                   "channel": {
                     "type": "string",
-                    "const": "sms"
+                    "const": "sms",
+                    "description": "The contact channel identifier."
                   },
                   "phone_number": {
                     "type": "string",
@@ -251,7 +253,8 @@
                   "properties": {
                     "class": {
                       "type": "string",
-                      "const": "standard_parcel"
+                      "const": "standard_parcel",
+                      "description": "The shipping class identifier."
                     },
                     "estimated_days": {
                       "type": "integer",
@@ -269,7 +272,8 @@
                   "properties": {
                     "class": {
                       "type": "string",
-                      "const": "freight"
+                      "const": "freight",
+                      "description": "The shipping class identifier."
                     },
                     "requires_signature": {
                       "type": "boolean",
@@ -327,7 +331,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "credit_card"
+              "const": "credit_card",
+              "description": "The payment method identifier."
             },
             "card_brand": {
               "type": "string",
@@ -381,7 +386,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "digital_wallet"
+              "const": "digital_wallet",
+              "description": "The payment method identifier."
             },
             "wallet_provider": {
               "description": "The wallet provider, either a known name or a custom string.",
@@ -416,7 +422,8 @@
           "properties": {
             "method": {
               "type": "string",
-              "const": "bank_transfer"
+              "const": "bank_transfer",
+              "description": "The payment method identifier."
             },
             "bank_name": {
               "type": "string",
@@ -452,7 +459,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "home_delivery"
+              "const": "home_delivery",
+              "description": "The fulfillment method identifier."
             },
             "address": {
               "type": "object",
@@ -534,7 +542,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "store_pickup"
+              "const": "store_pickup",
+              "description": "The fulfillment method identifier."
             },
             "store_id": {
               "type": "string",
@@ -551,7 +560,8 @@
                   "properties": {
                     "slot_type": {
                       "type": "string",
-                      "const": "scheduled"
+                      "const": "scheduled",
+                      "description": "The pickup slot type identifier."
                     },
                     "datetime": {
                       "type": "string",
@@ -569,7 +579,8 @@
                   "properties": {
                     "slot_type": {
                       "type": "string",
-                      "const": "asap"
+                      "const": "asap",
+                      "description": "The pickup slot type identifier."
                     },
                     "estimated_ready_minutes": {
                       "type": "integer",
@@ -591,7 +602,8 @@
           "properties": {
             "fulfillment_method": {
               "type": "string",
-              "const": "digital"
+              "const": "digital",
+              "description": "The fulfillment method identifier."
             },
             "delivery_email": {
               "type": "string",
@@ -614,7 +626,8 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "percentage"
+              "const": "percentage",
+              "description": "The discount type identifier."
             },
             "value": {
               "type": "number",
@@ -633,7 +646,8 @@
           "properties": {
             "type": {
               "type": "string",
-              "const": "fixed"
+              "const": "fixed",
+              "description": "The discount type identifier."
             },
             "amount": {
               "type": "number",
@@ -667,7 +681,8 @@
               "properties": {
                 "platform": {
                   "type": "string",
-                  "const": "web"
+                  "const": "web",
+                  "description": "The source platform identifier."
                 },
                 "device_type": {
                   "type": "string",
@@ -728,7 +743,8 @@
               "properties": {
                 "platform": {
                   "type": "string",
-                  "const": "app"
+                  "const": "app",
+                  "description": "The source platform identifier."
                 },
                 "app_version": {
                   "type": "string",
@@ -754,7 +770,8 @@
       "payment": {
         "properties": {
           "currency": {
-            "const": "USD"
+            "const": "USD",
+            "description": "ISO 4217 currency code."
           }
         }
       }
@@ -795,7 +812,8 @@
         "tax": {
           "properties": {
             "jurisdiction": {
-              "const": "CA"
+              "const": "CA",
+              "description": "Tax jurisdiction (state)."
             }
           }
         }

--- a/demo/static/schemas/next/web/choice-event.json
+++ b/demo/static/schemas/next/web/choice-event.json
@@ -13,7 +13,8 @@
     },
     "event": {
       "type": "string",
-      "const": "one_of_event"
+      "const": "one_of_event",
+      "description": "The event name."
     },
     "user_id": {
       "description": "The user's ID.",
@@ -42,15 +43,18 @@
           "properties": {
             "payment_type": {
               "type": "string",
+              "description": "The type of payment.",
               "enum": ["credit_card", "debit_card"],
               "examples": ["credit_card"]
             },
             "card_number": {
               "type": "string",
+              "description": "The card number.",
               "examples": ["1234-5678-9012-3456"]
             },
             "expiry_date": {
               "type": "string",
+              "description": "The card expiry date.",
               "examples": ["12/26"]
             }
           },
@@ -62,11 +66,13 @@
           "properties": {
             "payment_type": {
               "type": "string",
-              "const": "paypal"
+              "const": "paypal",
+              "description": "The type of payment."
             },
             "email": {
               "type": "string",
               "format": "email",
+              "description": "The PayPal account email address.",
               "examples": ["test@example.com"]
             }
           },

--- a/demo/static/schemas/next/web/complex-event.json
+++ b/demo/static/schemas/next/web/complex-event.json
@@ -95,14 +95,17 @@
             "properties": {
               "street": {
                 "type": "string",
+                "description": "The street address.",
                 "examples": ["123 Main St"]
               },
               "city": {
                 "type": "string",
+                "description": "The city name.",
                 "examples": ["New York"]
               },
               "zip": {
                 "type": "string",
+                "description": "The postal ZIP code.",
                 "examples": ["10001"]
               }
             }
@@ -167,10 +170,12 @@
       "properties": {
         "prop_a": {
           "type": "string",
+          "description": "First arbitrary string property.",
           "examples": ["some_value"]
         },
         "prop_b": {
           "type": "string",
+          "description": "Second arbitrary string property.",
           "examples": ["another_value"]
         }
       },
@@ -190,10 +195,12 @@
       "properties": {
         "credit_card": {
           "type": "number",
+          "description": "The credit card number.",
           "examples": [1234567890123456]
         },
         "billing_address": {
           "type": "string",
+          "description": "The billing address associated with the credit card.",
           "examples": ["123 Billing Address, Anytown, USA"]
         }
       },

--- a/demo/static/schemas/next/web/root-any-of-event.json
+++ b/demo/static/schemas/next/web/root-any-of-event.json
@@ -13,7 +13,8 @@
     },
     "event": {
       "type": "string",
-      "const": "any_of_event"
+      "const": "any_of_event",
+      "description": "The event name."
     }
   },
   "required": ["$schema", "event"],
@@ -24,6 +25,7 @@
       "properties": {
         "param_c": {
           "type": "string",
+          "description": "An optional string parameter for option C.",
           "examples": ["example_c"]
         }
       }
@@ -33,6 +35,7 @@
       "properties": {
         "param_d": {
           "type": "boolean",
+          "description": "An optional boolean parameter for option D.",
           "examples": [true]
         }
       }

--- a/demo/static/schemas/next/web/root-choice-event.json
+++ b/demo/static/schemas/next/web/root-choice-event.json
@@ -26,10 +26,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_a"
+              "const": "option_a",
+              "description": "The event name."
             },
             "param_a": {
               "type": "string",
+              "description": "A string parameter for option A.",
               "examples": ["example_a"]
             }
           }
@@ -41,10 +43,12 @@
           "properties": {
             "event": {
               "type": "string",
-              "const": "option_b"
+              "const": "option_b",
+              "description": "The event name."
             },
             "param_b": {
               "type": "integer",
+              "description": "An integer parameter for option B.",
               "examples": [123]
             }
           }


### PR DESCRIPTION
## Summary

- Adds `"description"` fields to 120 JSON schema properties across 16 demo schema files (versions 1.1.1, 1.2.0, 1.3.0, next) that were triggering `tracking-schema/require-description` lint warnings
- No logic or schema structure changes — descriptions only

## Test plan

- [x] `npm run lint` — 0 warnings (was 120)
- [x] All 358 tests pass
- [x] `npm run validate-schemas` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)