### PR TITLE
Publish tracking target constraints package

### DIFF
--- a/.github/workflows/release-constraints.yml
+++ b/.github/workflows/release-constraints.yml
@@ -1,0 +1,57 @@
+name: Release Constraints Package
+
+on:
+  push:
+    tags:
+      - 'constraints-v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build static constraints bundle
+        run: npm run build -w tracking-target-constraints
+
+      - name: Verify package version matches tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/tracking-target-constraints/package.json').version")
+          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="${TAG_VERSION#constraints-v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package version ($PACKAGE_VERSION)."
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+
+      - name: Publish package
+        working-directory: ./packages/tracking-target-constraints
+        run: npm publish --provenance
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/constraintSchemaPaths.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/constraintSchemaPaths.test.js
@@ -84,6 +84,19 @@ describe('resolveConstraintSchemaPath — when package root not found', () => {
     const result = resolveConstraintSchemaPath('/constraints/foo.json');
     expect(result).toBe(path.join(thirdCandidate, 'foo.json'));
   });
+
+  it('falls back to node_modules package when monorepo candidates are missing', () => {
+    const installedPackageCandidate = path.resolve(
+      process.cwd(),
+      'node_modules',
+      'tracking-target-constraints',
+    );
+    fs.existsSync.mockImplementation((p) => p === installedPackageCandidate);
+
+    const result = resolveConstraintSchemaPath('/constraints/foo.json');
+
+    expect(result).toBe(path.join(installedPackageCandidate, 'foo.json'));
+  });
 });
 
 describe('resolveConstraintSchemaPath — HTTP/HTTPS URIs', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/constraintSchemaPaths.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/constraintSchemaPaths.js
@@ -1,22 +1,18 @@
 import path from 'path';
 import fs from 'fs';
 
+function buildCandidatePaths(baseSegments, packageName) {
+  return [
+    path.resolve(process.cwd(), ...baseSegments, packageName),
+    path.resolve(process.cwd(), '..', ...baseSegments, packageName),
+    path.resolve(process.cwd(), '..', '..', ...baseSegments, packageName),
+  ];
+}
+
 function getConstraintsPackageRoot() {
   const candidates = [
-    path.resolve(process.cwd(), 'packages', 'tracking-target-constraints'),
-    path.resolve(
-      process.cwd(),
-      '..',
-      'packages',
-      'tracking-target-constraints',
-    ),
-    path.resolve(
-      process.cwd(),
-      '..',
-      '..',
-      'packages',
-      'tracking-target-constraints',
-    ),
+    ...buildCandidatePaths(['packages'], 'tracking-target-constraints'),
+    ...buildCandidatePaths(['node_modules'], 'tracking-target-constraints'),
   ];
 
   return candidates.find((candidate) => fs.existsSync(candidate));

--- a/packages/tracking-target-constraints/README.md
+++ b/packages/tracking-target-constraints/README.md
@@ -25,6 +25,20 @@ npm run test -w tracking-target-constraints
 npm run build -w tracking-target-constraints
 ```
 
+## npm package
+
+The package can be consumed directly after publishing:
+
+```bash
+npm install tracking-target-constraints
+```
+
+That install includes:
+
+- `manifest.json`
+- `schemas/...`
+- `dist/...`
+
 ## Publishing as static URLs
 
 Deploy `packages/tracking-target-constraints/dist` to any static host (for example Cloudflare Pages, Netlify, Vercel static output, S3+CloudFront).

--- a/packages/tracking-target-constraints/package.json
+++ b/packages/tracking-target-constraints/package.json
@@ -1,9 +1,17 @@
 {
   "name": "tracking-target-constraints",
   "version": "0.1.0",
-  "private": true,
   "license": "MIT",
   "description": "Reusable target constraint schemas for tracking contracts.",
+  "files": [
+    "schemas",
+    "manifest.json",
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest __tests__/firebase-v1-constraints.test.js --runInBand",
     "build": "node scripts/build-static.mjs"


### PR DESCRIPTION
## Summary
- publish  as a public npm package with packaged schema assets
- teach constraint resolution to find installed  packages in 
- add a dedicated GitHub Actions release workflow for  tags

Closes #123

## Validation
- npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/constraintSchemaPaths.test.js --runInBand
- npm run test -w tracking-target-constraints
- npm run build -w tracking-target-constraints
- npm pack --dry-run
- full pre-commit hooks passed (jest, validate-schemas, eslint)
