### PR TITLE
Add sync-version-from-next command

### DIFF
--- a/demo/static/schemas/1.1.1/components/dataLayer.json
+++ b/demo/static/schemas/1.1.1/components/dataLayer.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
   "title": "dataLayer",
   "description": "Schema for the object structure pushed to the dataLayer.",
   "type": "object",

--- a/demo/static/schemas/1.1.1/components/ga4.json
+++ b/demo/static/schemas/1.1.1/components/ga4.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tracking-docs-demo.buchert.digital/schemas/components/ga4.json",
+  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/ga4.json",
   "$defs": {
     "eventName": {
       "allOf": [

--- a/demo/static/schemas/1.1.1/components/product.json
+++ b/demo/static/schemas/1.1.1/components/product.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
   "title": "A Product",
   "description": "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",
   "type": "object",

--- a/demo/static/schemas/1.3.0/mobile/add-payment-info-event.json
+++ b/demo/static/schemas/1.3.0/mobile/add-payment-info-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/add-shipping-info-event.json
+++ b/demo/static/schemas/1.3.0/mobile/add-shipping-info-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/add-to-cart-event.json
+++ b/demo/static/schemas/1.3.0/mobile/add-to-cart-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/add-to-wishlist-event.json
+++ b/demo/static/schemas/1.3.0/mobile/add-to-wishlist-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/begin-checkout-event.json
+++ b/demo/static/schemas/1.3.0/mobile/begin-checkout-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/checkout-options-event.json
+++ b/demo/static/schemas/1.3.0/mobile/checkout-options-event.json
@@ -69,7 +69,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/checkout-options-event.json
+++ b/demo/static/schemas/1.3.0/mobile/checkout-options-event.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+  "$dynamicAnchor": "checkoutOptionsEvent",
+  "$comment": "Metadata example for the schema JSON viewer on a mobile event schema.",
   "title": "Checkout Options",
   "description": "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
   "x-tracking-targets": [
@@ -67,7 +69,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/custom-event.json
+++ b/demo/static/schemas/1.3.0/mobile/custom-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json"
     },
     "event": {
       "type": "string",
@@ -43,6 +43,77 @@
         "const": "US"
       },
       "examples": ["DE"]
+    },
+    "status_code": {
+      "type": "string",
+      "description": "Complex not example: disallow success-like codes via nested anyOf.",
+      "not": {
+        "anyOf": [
+          {
+            "const": "200"
+          },
+          {
+            "pattern": "^2[0-9]{2}$"
+          },
+          {
+            "enum": ["ok", "success"]
+          }
+        ]
+      },
+      "examples": ["500"]
+    },
+    "region_bucket": {
+      "type": "string",
+      "description": "Complex not example: disallow restricted prefixes and exact values.",
+      "not": {
+        "anyOf": [
+          {
+            "pattern": "^internal-"
+          },
+          {
+            "enum": ["private", "secret"]
+          },
+          {
+            "allOf": [
+              {
+                "minLength": 2
+              },
+              {
+                "maxLength": 2
+              },
+              {
+                "pattern": "^[A-Z]{2}$"
+              }
+            ]
+          }
+        ]
+      },
+      "examples": ["public-west"]
+    },
+    "sku": {
+      "type": "string",
+      "description": "Complex not example: disallow short numeric-only IDs and known placeholders.",
+      "not": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9]{1,4}$"
+          },
+          {
+            "enum": ["unknown", "tbd", "na"]
+          },
+          {
+            "allOf": [
+              {
+                "pattern": "^[A-Z0-9_-]+$"
+              },
+              {
+                "maxLength": 3
+              }
+            ]
+          }
+        ]
+      },
+      "examples": ["SKU-12345"]
     }
   },
   "required": ["$schema", "event"],

--- a/demo/static/schemas/1.3.0/mobile/custom-event.json
+++ b/demo/static/schemas/1.3.0/mobile/custom-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/in-app-purchase-event.json
+++ b/demo/static/schemas/1.3.0/mobile/in-app-purchase-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/login-with-user-properties-event.json
+++ b/demo/static/schemas/1.3.0/mobile/login-with-user-properties-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/purchase-event.json
+++ b/demo/static/schemas/1.3.0/mobile/purchase-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/refund-event.json
+++ b/demo/static/schemas/1.3.0/mobile/refund-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/remove-from-cart-event.json
+++ b/demo/static/schemas/1.3.0/mobile/remove-from-cart-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/screen-view-event.json
+++ b/demo/static/schemas/1.3.0/mobile/screen-view-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/select-item-event.json
+++ b/demo/static/schemas/1.3.0/mobile/select-item-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/select-promotion-event.json
+++ b/demo/static/schemas/1.3.0/mobile/select-promotion-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/view-cart-event.json
+++ b/demo/static/schemas/1.3.0/mobile/view-cart-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/view-item-event.json
+++ b/demo/static/schemas/1.3.0/mobile/view-item-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/view-item-list-event.json
+++ b/demo/static/schemas/1.3.0/mobile/view-item-list-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/mobile/view-promotion-event.json
+++ b/demo/static/schemas/1.3.0/mobile/view-promotion-event.json
@@ -14,7 +14,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/add-to-cart-event.json
+++ b/demo/static/schemas/1.3.0/web/add-to-cart-event.json
@@ -8,7 +8,7 @@
   "properties": {
     "$schema": {
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
       "type": "string"
     },
     "event": {

--- a/demo/static/schemas/1.3.0/web/battle-test-event.json
+++ b/demo/static/schemas/1.3.0/web/battle-test-event.json
@@ -10,7 +10,7 @@
     "$schema": {
       "type": "string",
       "description": "Schema validation URL.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/choice-event.json
+++ b/demo/static/schemas/1.3.0/web/choice-event.json
@@ -9,7 +9,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/complex-event.json
+++ b/demo/static/schemas/1.3.0/web/complex-event.json
@@ -21,7 +21,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/complex-event.json
+++ b/demo/static/schemas/1.3.0/web/complex-event.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
+  "$comment": "Authoring example for schema metadata in the raw schema viewer.",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true
+  },
   "title": "Complex Event with Validation Constraints",
   "description": "A generic event demonstrating various validation constraints and recursive documentation capabilities.",
   "x-tracking-targets": ["web-datalayer-js"],
@@ -46,7 +51,7 @@
         },
         "attributes": {
           "type": "object",
-          "description": "Nested generic attributes.",
+          "description": "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
           "properties": {
             "segment": {
               "type": "string",
@@ -71,7 +76,15 @@
               "minimum": 0,
               "examples": [12]
             }
-          }
+          },
+          "examples": [
+            {
+              "segment": "premium",
+              "score": 95,
+              "loyalty_tier": "gold",
+              "custom_ltv": 12
+            }
+          ]
         },
         "addresses": {
           "type": "array",

--- a/demo/static/schemas/1.3.0/web/components/dataLayer.json
+++ b/demo/static/schemas/1.3.0/web/components/dataLayer.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/events/components/dataLayer.json",
+  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/components/dataLayer.json",
   "title": "dataLayer",
   "description": "Schema for the object structure pushed to the dataLayer.",
   "type": "object",

--- a/demo/static/schemas/1.3.0/web/components/ga4.json
+++ b/demo/static/schemas/1.3.0/web/components/ga4.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/events/components/ga4.json",
+  "$id": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/components/ga4.json",
   "$defs": {
     "eventName": {
       "allOf": [

--- a/demo/static/schemas/1.3.0/web/conditional-event.json
+++ b/demo/static/schemas/1.3.0/web/conditional-event.json
@@ -9,7 +9,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/nested-conditional-event.json
+++ b/demo/static/schemas/1.3.0/web/nested-conditional-event.json
@@ -9,7 +9,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/purchase-event.json
+++ b/demo/static/schemas/1.3.0/web/purchase-event.json
@@ -9,7 +9,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/root-any-of-event.json
+++ b/demo/static/schemas/1.3.0/web/root-any-of-event.json
@@ -9,7 +9,7 @@
     "$schema": {
       "type": "string",
       "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-      "const": "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json"
+      "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json"
     },
     "event": {
       "type": "string",

--- a/demo/static/schemas/1.3.0/web/root-choice-event.json
+++ b/demo/static/schemas/1.3.0/web/root-choice-event.json
@@ -11,7 +11,7 @@
         "$schema": {
           "type": "string",
           "description": "Defines the structure of the event. This can be used to validate an event against the schema provided.",
-          "const": "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json"
+          "const": "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json"
         }
       },
       "required": ["$schema"]

--- a/demo/versioned_docs/version-1.1.1/add-to-cart-event.mdx
+++ b/demo/versioned_docs/version-1.1.1/add-to-cart-event.mdx
@@ -70,7 +70,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
             minItems: 1,
             items: {
               $schema: "https://json-schema.org/draft/2020-12/schema",
-              $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+              $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
               title: "A Product",
               description:
                 "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",
@@ -324,7 +324,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -359,7 +359,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
     },
     "components/product.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
       title: "A Product",
       description:
         "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",
@@ -590,7 +590,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -625,7 +625,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
     },
     "components/product.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
       title: "A Product",
       description:
         "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",

--- a/demo/versioned_docs/version-1.1.1/complex-event.mdx
+++ b/demo/versioned_docs/version-1.1.1/complex-event.mdx
@@ -586,7 +586,7 @@ A generic event demonstrating various validation constraints and recursive docum
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -993,7 +993,7 @@ A generic event demonstrating various validation constraints and recursive docum
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",

--- a/demo/versioned_docs/version-1.1.1/purchase-event.mdx
+++ b/demo/versioned_docs/version-1.1.1/purchase-event.mdx
@@ -97,7 +97,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
             minItems: 1,
             items: {
               $schema: "https://json-schema.org/draft/2020-12/schema",
-              $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+              $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
               title: "A Product",
               description:
                 "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",
@@ -413,7 +413,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -448,7 +448,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
     },
     "components/product.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
       title: "A Product",
       description:
         "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",
@@ -741,7 +741,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
     },
     "components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -776,7 +776,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
     },
     "components/product.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/components/product.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.1.1/components/product.json",
       title: "A Product",
       description:
         "A product object representing an item for use within a purchase event, based on Google Analytics 4 ecommerce event specifications.",

--- a/demo/versioned_docs/version-1.3.0/event-reference/01-complex-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/01-complex-event.mdx
@@ -144,7 +144,7 @@ A generic event demonstrating various validation constraints and recursive docum
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
       },
       timestamp: {
         type: "integer",
@@ -282,7 +282,7 @@ A generic event demonstrating various validation constraints and recursive docum
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
       },
       event: {
         type: "string",
@@ -505,7 +505,7 @@ A generic event demonstrating various validation constraints and recursive docum
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
         },
         event: {
           type: "string",
@@ -831,7 +831,7 @@ A generic event demonstrating various validation constraints and recursive docum
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
       },
       timestamp: {
         type: "integer",
@@ -972,7 +972,7 @@ A generic event demonstrating various validation constraints and recursive docum
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/01-complex-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/01-complex-event.mdx
@@ -74,7 +74,16 @@ A generic event demonstrating various validation constraints and recursive docum
           },
           attributes: {
             type: "object",
-            description: "Nested generic attributes.",
+            description:
+              "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
+            examples: [
+              {
+                segment: "premium",
+                score: 95,
+                loyalty_tier: "gold",
+                custom_ltv: 12,
+              },
+            ],
             additionalProperties: {
               type: "string",
               description:
@@ -240,11 +249,21 @@ A generic event demonstrating various validation constraints and recursive docum
         examples: ["must_be_this"],
       },
     },
+    $comment: "Authoring example for schema metadata in the raw schema viewer.",
+    $vocabulary: {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    },
     "x-tracking-targets": ["web-datalayer-js"],
   }}
   sourceSchema={{
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
+    $comment: "Authoring example for schema metadata in the raw schema viewer.",
+    $vocabulary: {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    },
     title: "Complex Event with Validation Constraints",
     description:
       "A generic event demonstrating various validation constraints and recursive documentation capabilities.",
@@ -293,7 +312,8 @@ A generic event demonstrating various validation constraints and recursive docum
           },
           attributes: {
             type: "object",
-            description: "Nested generic attributes.",
+            description:
+              "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
             properties: {
               segment: {
                 type: "string",
@@ -321,6 +341,14 @@ A generic event demonstrating various validation constraints and recursive docum
                 examples: [12],
               },
             },
+            examples: [
+              {
+                segment: "premium",
+                score: 95,
+                loyalty_tier: "gold",
+                custom_ltv: 12,
+              },
+            ],
           },
           addresses: {
             type: "array",
@@ -453,6 +481,12 @@ A generic event demonstrating various validation constraints and recursive docum
     "web/complex-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
+      $comment:
+        "Authoring example for schema metadata in the raw schema viewer.",
+      $vocabulary: {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      },
       title: "Complex Event with Validation Constraints",
       description:
         "A generic event demonstrating various validation constraints and recursive documentation capabilities.",
@@ -501,7 +535,8 @@ A generic event demonstrating various validation constraints and recursive docum
             },
             attributes: {
               type: "object",
-              description: "Nested generic attributes.",
+              description:
+                "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
               properties: {
                 segment: {
                   type: "string",
@@ -529,6 +564,14 @@ A generic event demonstrating various validation constraints and recursive docum
                   examples: [12],
                 },
               },
+              examples: [
+                {
+                  segment: "premium",
+                  score: 95,
+                  loyalty_tier: "gold",
+                  custom_ltv: 12,
+                },
+              ],
             },
             addresses: {
               type: "array",
@@ -718,7 +761,16 @@ A generic event demonstrating various validation constraints and recursive docum
           },
           attributes: {
             type: "object",
-            description: "Nested generic attributes.",
+            description:
+              "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
+            examples: [
+              {
+                segment: "premium",
+                score: 95,
+                loyalty_tier: "gold",
+                custom_ltv: 12,
+              },
+            ],
             additionalProperties: {
               type: "string",
               description:
@@ -884,6 +936,11 @@ A generic event demonstrating various validation constraints and recursive docum
         examples: ["must_be_this"],
       },
     },
+    $comment: "Authoring example for schema metadata in the raw schema viewer.",
+    $vocabulary: {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    },
     "x-tracking-targets": ["web-datalayer-js"],
   }}
   sourcePath={"web/complex-event.json"}
@@ -891,6 +948,12 @@ A generic event demonstrating various validation constraints and recursive docum
     "web/complex-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
+      $comment:
+        "Authoring example for schema metadata in the raw schema viewer.",
+      $vocabulary: {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      },
       title: "Complex Event with Validation Constraints",
       description:
         "A generic event demonstrating various validation constraints and recursive documentation capabilities.",
@@ -939,7 +1002,8 @@ A generic event demonstrating various validation constraints and recursive docum
             },
             attributes: {
               type: "object",
-              description: "Nested generic attributes.",
+              description:
+                "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
               properties: {
                 segment: {
                   type: "string",
@@ -967,6 +1031,14 @@ A generic event demonstrating various validation constraints and recursive docum
                   examples: [12],
                 },
               },
+              examples: [
+                {
+                  segment: "premium",
+                  score: 95,
+                  loyalty_tier: "gold",
+                  custom_ltv: 12,
+                },
+              ],
             },
             addresses: {
               type: "array",

--- a/demo/versioned_docs/version-1.3.0/event-reference/02-purchase-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/02-purchase-event.mdx
@@ -272,7 +272,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
       },
     },
     "x-tracking-targets": ["web-datalayer-js"],
@@ -291,7 +291,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
       },
       event: {
         type: "string",
@@ -369,7 +369,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
         },
         event: {
           type: "string",
@@ -842,7 +842,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
       },
     },
     "x-tracking-targets": ["web-datalayer-js"],
@@ -863,7 +863,7 @@ A purchase event fires when a user completes a purchase. Based on Google Analyti
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/03-add-to-cart-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/03-add-to-cart-event.mdx
@@ -241,7 +241,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
         type: "string",
       },
     },
@@ -260,7 +260,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
         type: "string",
       },
       event: {
@@ -307,7 +307,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
           type: "string",
         },
         event: {
@@ -718,7 +718,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
         type: "string",
       },
     },
@@ -739,7 +739,7 @@ An add_to_cart event fires when a user adds one or more items to their shopping 
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
           type: "string",
         },
         event: {

--- a/demo/versioned_docs/version-1.3.0/event-reference/04-root-any-of-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/04-root-any-of-event.mdx
@@ -55,7 +55,7 @@ An example event that has anyOf at the root level.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
       },
     },
     "x-tracking-targets": ["web-datalayer-js"],
@@ -96,7 +96,7 @@ An example event that has anyOf at the root level.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
       },
       event: {
         type: "string",
@@ -144,7 +144,7 @@ An example event that has anyOf at the root level.
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
         },
         event: {
           type: "string",
@@ -222,7 +222,7 @@ An example event that has anyOf at the root level.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
       },
     },
     "x-tracking-targets": ["web-datalayer-js"],
@@ -265,7 +265,7 @@ An example event that has anyOf at the root level.
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/01-option_a.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/01-option_a.mdx
@@ -27,7 +27,7 @@ This is the description for Param A.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
       },
       event: {
         type: "string",
@@ -57,7 +57,7 @@ This is the description for Param A.
             description:
               "Defines the structure of the event. This can be used to validate an event against the schema provided.",
             const:
-              "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+              "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
           },
         },
         required: ["$schema"],
@@ -120,7 +120,7 @@ This is the description for Param A.
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],
@@ -183,7 +183,7 @@ This is the description for Param A.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
       },
       event: {
         type: "string",
@@ -215,7 +215,7 @@ This is the description for Param A.
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],

--- a/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/02-option_b.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/02-option_b.mdx
@@ -27,7 +27,7 @@ An example event that has oneOf at the root level.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
       },
       event: {
         type: "string",
@@ -57,7 +57,7 @@ An example event that has oneOf at the root level.
             description:
               "Defines the structure of the event. This can be used to validate an event against the schema provided.",
             const:
-              "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+              "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
           },
         },
         required: ["$schema"],
@@ -120,7 +120,7 @@ An example event that has oneOf at the root level.
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],
@@ -183,7 +183,7 @@ An example event that has oneOf at the root level.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
       },
       event: {
         type: "string",
@@ -215,7 +215,7 @@ An example event that has oneOf at the root level.
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],

--- a/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/index.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/05-root-choice-event/index.mdx
@@ -54,7 +54,7 @@ Please select one of the following options:
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
       },
     },
     "x-tracking-targets": ["web-datalayer-js"],
@@ -113,7 +113,7 @@ Please select one of the following options:
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],

--- a/demo/versioned_docs/version-1.3.0/event-reference/06-choice-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/06-choice-event.mdx
@@ -55,7 +55,7 @@ An example event that uses oneOf and anyOf.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
       },
       user_id: {
         description: "The user's ID.",
@@ -137,7 +137,7 @@ An example event that uses oneOf and anyOf.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
       },
       event: {
         type: "string",
@@ -226,7 +226,7 @@ An example event that uses oneOf and anyOf.
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
         },
         event: {
           type: "string",
@@ -345,7 +345,7 @@ An example event that uses oneOf and anyOf.
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
       },
       user_id: {
         description: "The user's ID.",
@@ -429,7 +429,7 @@ An example event that uses oneOf and anyOf.
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/07-conditional-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/07-conditional-event.mdx
@@ -57,7 +57,7 @@ An event demonstrating if/then/else conditional properties. The postal code form
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
       },
       country: {
         type: "string",
@@ -117,7 +117,7 @@ An event demonstrating if/then/else conditional properties. The postal code form
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
       },
       event: {
         type: "string",
@@ -185,7 +185,7 @@ An event demonstrating if/then/else conditional properties. The postal code form
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
         },
         event: {
           type: "string",
@@ -284,7 +284,7 @@ An event demonstrating if/then/else conditional properties. The postal code form
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
       },
       country: {
         type: "string",
@@ -346,7 +346,7 @@ An event demonstrating if/then/else conditional properties. The postal code form
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/08-nested-conditional-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/08-nested-conditional-event.mdx
@@ -57,7 +57,7 @@ An event demonstrating if/then/else conditional properties nested inside a prope
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
       },
       order_id: {
         type: "string",
@@ -128,7 +128,7 @@ An event demonstrating if/then/else conditional properties nested inside a prope
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
       },
       event: {
         type: "string",
@@ -207,7 +207,7 @@ An event demonstrating if/then/else conditional properties nested inside a prope
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
         },
         event: {
           type: "string",
@@ -317,7 +317,7 @@ An event demonstrating if/then/else conditional properties nested inside a prope
         description:
           "Defines the structure of the event. This can be used to validate an event against the schema provided.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
       },
       order_id: {
         type: "string",
@@ -390,7 +390,7 @@ An event demonstrating if/then/else conditional properties nested inside a prope
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/09-battle-test-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/09-battle-test-event.mdx
@@ -56,7 +56,7 @@ A stress-test event exercising every nesting combination: oneOf/anyOf inside if/
         type: "string",
         description: "Schema validation URL.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
       },
       user: {
         type: "object",
@@ -915,7 +915,7 @@ A stress-test event exercising every nesting combination: oneOf/anyOf inside if/
         type: "string",
         description: "Schema validation URL.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
       },
       event: {
         type: "string",
@@ -1781,7 +1781,7 @@ A stress-test event exercising every nesting combination: oneOf/anyOf inside if/
           type: "string",
           description: "Schema validation URL.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
         },
         event: {
           type: "string",
@@ -2683,7 +2683,7 @@ A stress-test event exercising every nesting combination: oneOf/anyOf inside if/
         type: "string",
         description: "Schema validation URL.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
       },
       user: {
         type: "object",
@@ -3544,7 +3544,7 @@ A stress-test event exercising every nesting combination: oneOf/anyOf inside if/
           type: "string",
           description: "Schema validation URL.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/index.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/index.mdx
@@ -125,7 +125,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/complex-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
         },
         event: {
           type: "string",
@@ -334,7 +334,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/purchase-event.json",
         },
         event: {
           type: "string",
@@ -561,7 +561,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/add-to-cart-event.json",
           type: "string",
         },
         event: {
@@ -606,7 +606,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/root-any-of-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-any-of-event.json",
         },
         event: {
           type: "string",
@@ -654,7 +654,7 @@ Please select one of the following options:
               description:
                 "Defines the structure of the event. This can be used to validate an event against the schema provided.",
               const:
-                "https://tracking-docs-demo.buchert.digital/schemas/web/root-choice-event.json",
+                "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/root-choice-event.json",
             },
           },
           required: ["$schema"],
@@ -713,7 +713,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/choice-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/choice-event.json",
         },
         event: {
           type: "string",
@@ -801,7 +801,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/conditional-event.json",
         },
         event: {
           type: "string",
@@ -867,7 +867,7 @@ Please select one of the following options:
           description:
             "Defines the structure of the event. This can be used to validate an event against the schema provided.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/nested-conditional-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/nested-conditional-event.json",
         },
         event: {
           type: "string",
@@ -944,7 +944,7 @@ Please select one of the following options:
           type: "string",
           description: "Schema validation URL.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/web/battle-test-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/battle-test-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/event-reference/index.mdx
+++ b/demo/versioned_docs/version-1.3.0/event-reference/index.mdx
@@ -65,7 +65,7 @@ Please select one of the following options:
     },
     "web/components/dataLayer.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
-      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/events/components/dataLayer.json",
+      $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/components/dataLayer.json",
       title: "dataLayer",
       description: "Schema for the object structure pushed to the dataLayer.",
       type: "object",
@@ -101,6 +101,12 @@ Please select one of the following options:
     "web/complex-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/web/complex-event.json",
+      $comment:
+        "Authoring example for schema metadata in the raw schema viewer.",
+      $vocabulary: {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+      },
       title: "Complex Event with Validation Constraints",
       description:
         "A generic event demonstrating various validation constraints and recursive documentation capabilities.",
@@ -149,7 +155,8 @@ Please select one of the following options:
             },
             attributes: {
               type: "object",
-              description: "Nested generic attributes.",
+              description:
+                "Nested generic attributes. Declared keys are documented below; undeclared keys are allowed when they satisfy the schema constraint row for additionalProperties.",
               properties: {
                 segment: {
                   type: "string",
@@ -177,6 +184,14 @@ Please select one of the following options:
                   examples: [12],
                 },
               },
+              examples: [
+                {
+                  segment: "premium",
+                  score: 95,
+                  loyalty_tier: "gold",
+                  custom_ltv: 12,
+                },
+              ],
             },
             addresses: {
               type: "array",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/01-screen-view-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/01-screen-view-event.mdx
@@ -46,7 +46,7 @@ A screen_view event example focused on Android and iOS Firebase implementations.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
       },
       event: {
         type: "string",
@@ -92,7 +92,7 @@ A screen_view event example focused on Android and iOS Firebase implementations.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
       },
       event: {
         type: "string",
@@ -137,7 +137,7 @@ A screen_view event example focused on Android and iOS Firebase implementations.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
         },
         event: {
           type: "string",
@@ -198,7 +198,7 @@ A screen_view event example focused on Android and iOS Firebase implementations.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
       },
       event: {
         type: "string",
@@ -246,7 +246,7 @@ A screen_view event example focused on Android and iOS Firebase implementations.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/02-login-with-user-properties-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/02-login-with-user-properties-event.mdx
@@ -32,7 +32,7 @@ A login event example with Firebase user_properties for Android and iOS.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
       },
       event: {
         type: "string",
@@ -96,7 +96,7 @@ A login event example with Firebase user_properties for Android and iOS.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
       },
       event: {
         type: "string",
@@ -163,7 +163,7 @@ A login event example with Firebase user_properties for Android and iOS.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
         },
         event: {
           type: "string",
@@ -232,7 +232,7 @@ A login event example with Firebase user_properties for Android and iOS.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
       },
       event: {
         type: "string",
@@ -298,7 +298,7 @@ A login event example with Firebase user_properties for Android and iOS.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/03-checkout-options-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/03-checkout-options-event.mdx
@@ -20,6 +20,9 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
     description:
       "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
     type: "object",
+    $dynamicAnchor: "checkoutOptionsEvent",
+    $comment:
+      "Metadata example for the schema JSON viewer on a mobile event schema.",
     "x-tracking-targets": [
       "android-firebase-kotlin-sdk",
       "android-firebase-java-sdk",
@@ -55,7 +58,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -150,6 +153,9 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
   sourceSchema={{
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+    $dynamicAnchor: "checkoutOptionsEvent",
+    $comment:
+      "Metadata example for the schema JSON viewer on a mobile event schema.",
     title: "Checkout Options",
     description:
       "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
@@ -194,7 +200,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -287,6 +293,9 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
     "mobile/checkout-options-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+      $dynamicAnchor: "checkoutOptionsEvent",
+      $comment:
+        "Metadata example for the schema JSON viewer on a mobile event schema.",
       title: "Checkout Options",
       description:
         "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
@@ -331,7 +340,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",
@@ -429,6 +438,9 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
     description:
       "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
     type: "object",
+    $dynamicAnchor: "checkoutOptionsEvent",
+    $comment:
+      "Metadata example for the schema JSON viewer on a mobile event schema.",
     "x-tracking-targets": [
       "android-firebase-kotlin-sdk",
       "android-firebase-java-sdk",
@@ -464,7 +476,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -561,6 +573,9 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
     "mobile/checkout-options-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+      $dynamicAnchor: "checkoutOptionsEvent",
+      $comment:
+        "Metadata example for the schema JSON viewer on a mobile event schema.",
       title: "Checkout Options",
       description:
         "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
@@ -605,7 +620,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/03-checkout-options-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/03-checkout-options-event.mdx
@@ -58,7 +58,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -200,7 +200,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -340,7 +340,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",
@@ -476,7 +476,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
       },
       event: {
         type: "string",
@@ -620,7 +620,7 @@ Mobile checkout example with oneOf, anyOf, and platform-specific conditional fie
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/04-view-promotion-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/04-view-promotion-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user views a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
       },
       event: {
         type: "string",
@@ -260,7 +260,7 @@ Triggered when a user views a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
       },
       event: {
         type: "string",
@@ -315,7 +315,7 @@ Triggered when a user views a promotion.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
         },
         event: {
           type: "string",
@@ -538,7 +538,7 @@ Triggered when a user views a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
       },
       event: {
         type: "string",
@@ -755,7 +755,7 @@ Triggered when a user views a promotion.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/05-select-promotion-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/05-select-promotion-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user selects a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
       },
       event: {
         type: "string",
@@ -260,7 +260,7 @@ Triggered when a user selects a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
       },
       event: {
         type: "string",
@@ -315,7 +315,7 @@ Triggered when a user selects a promotion.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
         },
         event: {
           type: "string",
@@ -538,7 +538,7 @@ Triggered when a user selects a promotion.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
       },
       event: {
         type: "string",
@@ -755,7 +755,7 @@ Triggered when a user selects a promotion.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/06-view-item-list-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/06-view-item-list-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user views an item list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
       },
       event: {
         type: "string",
@@ -250,7 +250,7 @@ Triggered when a user views an item list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
       },
       event: {
         type: "string",
@@ -295,7 +295,7 @@ Triggered when a user views an item list.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
         },
         event: {
           type: "string",
@@ -508,7 +508,7 @@ Triggered when a user views an item list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
       },
       event: {
         type: "string",
@@ -715,7 +715,7 @@ Triggered when a user views an item list.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/07-select-item-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/07-select-item-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user selects an item from a list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
       },
       event: {
         type: "string",
@@ -250,7 +250,7 @@ Triggered when a user selects an item from a list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
       },
       event: {
         type: "string",
@@ -295,7 +295,7 @@ Triggered when a user selects an item from a list.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
         },
         event: {
           type: "string",
@@ -508,7 +508,7 @@ Triggered when a user selects an item from a list.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
       },
       event: {
         type: "string",
@@ -715,7 +715,7 @@ Triggered when a user selects an item from a list.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/08-view-item-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/08-view-item-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user views an item detail.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
       },
       event: {
         type: "string",
@@ -252,7 +252,7 @@ Triggered when a user views an item detail.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
       },
       event: {
         type: "string",
@@ -299,7 +299,7 @@ Triggered when a user views an item detail.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
         },
         event: {
           type: "string",
@@ -514,7 +514,7 @@ Triggered when a user views an item detail.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
       },
       event: {
         type: "string",
@@ -723,7 +723,7 @@ Triggered when a user views an item detail.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/09-add-to-wishlist-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/09-add-to-wishlist-event.mdx
@@ -45,7 +45,7 @@ Triggered when an item is added to wishlist.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
       },
       event: {
         type: "string",
@@ -252,7 +252,7 @@ Triggered when an item is added to wishlist.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
       },
       event: {
         type: "string",
@@ -299,7 +299,7 @@ Triggered when an item is added to wishlist.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
         },
         event: {
           type: "string",
@@ -514,7 +514,7 @@ Triggered when an item is added to wishlist.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
       },
       event: {
         type: "string",
@@ -723,7 +723,7 @@ Triggered when an item is added to wishlist.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/10-add-to-cart-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/10-add-to-cart-event.mdx
@@ -45,7 +45,7 @@ Triggered when an item is added to cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
       },
       event: {
         type: "string",
@@ -252,7 +252,7 @@ Triggered when an item is added to cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
       },
       event: {
         type: "string",
@@ -299,7 +299,7 @@ Triggered when an item is added to cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
         },
         event: {
           type: "string",
@@ -514,7 +514,7 @@ Triggered when an item is added to cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
       },
       event: {
         type: "string",
@@ -723,7 +723,7 @@ Triggered when an item is added to cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/11-view-cart-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/11-view-cart-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user views the cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
       },
       event: {
         type: "string",
@@ -252,7 +252,7 @@ Triggered when a user views the cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
       },
       event: {
         type: "string",
@@ -299,7 +299,7 @@ Triggered when a user views the cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
         },
         event: {
           type: "string",
@@ -514,7 +514,7 @@ Triggered when a user views the cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
       },
       event: {
         type: "string",
@@ -723,7 +723,7 @@ Triggered when a user views the cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/12-remove-from-cart-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/12-remove-from-cart-event.mdx
@@ -45,7 +45,7 @@ Triggered when an item is removed from cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
       },
       event: {
         type: "string",
@@ -252,7 +252,7 @@ Triggered when an item is removed from cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
       },
       event: {
         type: "string",
@@ -299,7 +299,7 @@ Triggered when an item is removed from cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
         },
         event: {
           type: "string",
@@ -514,7 +514,7 @@ Triggered when an item is removed from cart.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
       },
       event: {
         type: "string",
@@ -723,7 +723,7 @@ Triggered when an item is removed from cart.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/13-begin-checkout-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/13-begin-checkout-event.mdx
@@ -45,7 +45,7 @@ Triggered when a user begins checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
       },
       event: {
         type: "string",
@@ -257,7 +257,7 @@ Triggered when a user begins checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
       },
       event: {
         type: "string",
@@ -309,7 +309,7 @@ Triggered when a user begins checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
         },
         event: {
           type: "string",
@@ -529,7 +529,7 @@ Triggered when a user begins checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
       },
       event: {
         type: "string",
@@ -743,7 +743,7 @@ Triggered when a user begins checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/14-add-shipping-info-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/14-add-shipping-info-event.mdx
@@ -46,7 +46,7 @@ Triggered when a user submits shipping information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
       },
       event: {
         type: "string",
@@ -264,7 +264,7 @@ Triggered when a user submits shipping information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
       },
       event: {
         type: "string",
@@ -322,7 +322,7 @@ Triggered when a user submits shipping information in checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
         },
         event: {
           type: "string",
@@ -548,7 +548,7 @@ Triggered when a user submits shipping information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
       },
       event: {
         type: "string",
@@ -768,7 +768,7 @@ Triggered when a user submits shipping information in checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/15-add-payment-info-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/15-add-payment-info-event.mdx
@@ -46,7 +46,7 @@ Triggered when a user submits payment information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
       },
       event: {
         type: "string",
@@ -264,7 +264,7 @@ Triggered when a user submits payment information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
       },
       event: {
         type: "string",
@@ -322,7 +322,7 @@ Triggered when a user submits payment information in checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
         },
         event: {
           type: "string",
@@ -548,7 +548,7 @@ Triggered when a user submits payment information in checkout.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
       },
       event: {
         type: "string",
@@ -768,7 +768,7 @@ Triggered when a user submits payment information in checkout.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/16-purchase-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/16-purchase-event.mdx
@@ -52,7 +52,7 @@ Triggered when a purchase is completed.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
       },
       event: {
         type: "string",
@@ -289,7 +289,7 @@ Triggered when a purchase is completed.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
       },
       event: {
         type: "string",
@@ -373,7 +373,7 @@ Triggered when a purchase is completed.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
         },
         event: {
           type: "string",
@@ -632,7 +632,7 @@ Triggered when a purchase is completed.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
       },
       event: {
         type: "string",
@@ -871,7 +871,7 @@ Triggered when a purchase is completed.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/17-refund-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/17-refund-event.mdx
@@ -45,7 +45,7 @@ Triggered when a refund is issued.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
       },
       event: {
         type: "string",
@@ -272,7 +272,7 @@ Triggered when a refund is issued.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
       },
       event: {
         type: "string",
@@ -339,7 +339,7 @@ Triggered when a refund is issued.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
         },
         event: {
           type: "string",
@@ -574,7 +574,7 @@ Triggered when a refund is issued.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
       },
       event: {
         type: "string",
@@ -803,7 +803,7 @@ Triggered when a refund is issued.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/18-in-app-purchase-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/18-in-app-purchase-event.mdx
@@ -53,7 +53,7 @@ An in_app_purchase event example focused on Android and iOS Firebase implementat
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
       },
       event: {
         type: "string",
@@ -126,7 +126,7 @@ An in_app_purchase event example focused on Android and iOS Firebase implementat
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
       },
       event: {
         type: "string",
@@ -205,7 +205,7 @@ An in_app_purchase event example focused on Android and iOS Firebase implementat
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
         },
         event: {
           type: "string",
@@ -307,7 +307,7 @@ An in_app_purchase event example focused on Android and iOS Firebase implementat
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
       },
       event: {
         type: "string",
@@ -382,7 +382,7 @@ An in_app_purchase event example focused on Android and iOS Firebase implementat
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/19-custom-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/19-custom-event.mdx
@@ -45,7 +45,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -147,7 +147,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -248,7 +248,7 @@ A custom Firebase event example for mobile apps.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
         },
         event: {
           type: "string",
@@ -365,7 +365,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -469,7 +469,7 @@ A custom Firebase event example for mobile apps.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/19-custom-event.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/19-custom-event.mdx
@@ -45,7 +45,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -73,6 +73,51 @@ A custom Firebase event example for mobile apps.
           "Country code that must not be US (demo for not + const rendering).",
         not: { const: "US" },
         examples: ["DE"],
+      },
+      status_code: {
+        type: "string",
+        description:
+          "Complex not example: disallow success-like codes via nested anyOf.",
+        not: {
+          anyOf: [
+            { const: "200" },
+            { pattern: "^2[0-9]{2}$" },
+            { enum: ["ok", "success"] },
+          ],
+        },
+        examples: ["500"],
+      },
+      region_bucket: {
+        type: "string",
+        description:
+          "Complex not example: disallow restricted prefixes and exact values.",
+        not: {
+          anyOf: [
+            { pattern: "^internal-" },
+            { enum: ["private", "secret"] },
+            {
+              allOf: [
+                { minLength: 2 },
+                { maxLength: 2 },
+                { pattern: "^[A-Z]{2}$" },
+              ],
+            },
+          ],
+        },
+        examples: ["public-west"],
+      },
+      sku: {
+        type: "string",
+        description:
+          "Complex not example: disallow short numeric-only IDs and known placeholders.",
+        not: {
+          anyOf: [
+            { pattern: "^[0-9]{1,4}$" },
+            { enum: ["unknown", "tbd", "na"] },
+            { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+          ],
+        },
+        examples: ["SKU-12345"],
       },
       items: {
         type: "array",
@@ -102,7 +147,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -131,6 +176,51 @@ A custom Firebase event example for mobile apps.
         not: { const: "US" },
         examples: ["DE"],
       },
+      status_code: {
+        type: "string",
+        description:
+          "Complex not example: disallow success-like codes via nested anyOf.",
+        not: {
+          anyOf: [
+            { const: "200" },
+            { pattern: "^2[0-9]{2}$" },
+            { enum: ["ok", "success"] },
+          ],
+        },
+        examples: ["500"],
+      },
+      region_bucket: {
+        type: "string",
+        description:
+          "Complex not example: disallow restricted prefixes and exact values.",
+        not: {
+          anyOf: [
+            { pattern: "^internal-" },
+            { enum: ["private", "secret"] },
+            {
+              allOf: [
+                { minLength: 2 },
+                { maxLength: 2 },
+                { pattern: "^[A-Z]{2}$" },
+              ],
+            },
+          ],
+        },
+        examples: ["public-west"],
+      },
+      sku: {
+        type: "string",
+        description:
+          "Complex not example: disallow short numeric-only IDs and known placeholders.",
+        not: {
+          anyOf: [
+            { pattern: "^[0-9]{1,4}$" },
+            { enum: ["unknown", "tbd", "na"] },
+            { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+          ],
+        },
+        examples: ["SKU-12345"],
+      },
     },
     required: ["$schema", "event"],
     allOf: [
@@ -158,7 +248,7 @@ A custom Firebase event example for mobile apps.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
         },
         event: {
           type: "string",
@@ -186,6 +276,51 @@ A custom Firebase event example for mobile apps.
             "Country code that must not be US (demo for not + const rendering).",
           not: { const: "US" },
           examples: ["DE"],
+        },
+        status_code: {
+          type: "string",
+          description:
+            "Complex not example: disallow success-like codes via nested anyOf.",
+          not: {
+            anyOf: [
+              { const: "200" },
+              { pattern: "^2[0-9]{2}$" },
+              { enum: ["ok", "success"] },
+            ],
+          },
+          examples: ["500"],
+        },
+        region_bucket: {
+          type: "string",
+          description:
+            "Complex not example: disallow restricted prefixes and exact values.",
+          not: {
+            anyOf: [
+              { pattern: "^internal-" },
+              { enum: ["private", "secret"] },
+              {
+                allOf: [
+                  { minLength: 2 },
+                  { maxLength: 2 },
+                  { pattern: "^[A-Z]{2}$" },
+                ],
+              },
+            ],
+          },
+          examples: ["public-west"],
+        },
+        sku: {
+          type: "string",
+          description:
+            "Complex not example: disallow short numeric-only IDs and known placeholders.",
+          not: {
+            anyOf: [
+              { pattern: "^[0-9]{1,4}$" },
+              { enum: ["unknown", "tbd", "na"] },
+              { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+            ],
+          },
+          examples: ["SKU-12345"],
         },
       },
       required: ["$schema", "event"],
@@ -230,7 +365,7 @@ A custom Firebase event example for mobile apps.
         type: "string",
         description: "Defines the structure of the event.",
         const:
-          "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+          "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
       },
       event: {
         type: "string",
@@ -258,6 +393,51 @@ A custom Firebase event example for mobile apps.
           "Country code that must not be US (demo for not + const rendering).",
         not: { const: "US" },
         examples: ["DE"],
+      },
+      status_code: {
+        type: "string",
+        description:
+          "Complex not example: disallow success-like codes via nested anyOf.",
+        not: {
+          anyOf: [
+            { const: "200" },
+            { pattern: "^2[0-9]{2}$" },
+            { enum: ["ok", "success"] },
+          ],
+        },
+        examples: ["500"],
+      },
+      region_bucket: {
+        type: "string",
+        description:
+          "Complex not example: disallow restricted prefixes and exact values.",
+        not: {
+          anyOf: [
+            { pattern: "^internal-" },
+            { enum: ["private", "secret"] },
+            {
+              allOf: [
+                { minLength: 2 },
+                { maxLength: 2 },
+                { pattern: "^[A-Z]{2}$" },
+              ],
+            },
+          ],
+        },
+        examples: ["public-west"],
+      },
+      sku: {
+        type: "string",
+        description:
+          "Complex not example: disallow short numeric-only IDs and known placeholders.",
+        not: {
+          anyOf: [
+            { pattern: "^[0-9]{1,4}$" },
+            { enum: ["unknown", "tbd", "na"] },
+            { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+          ],
+        },
+        examples: ["SKU-12345"],
       },
       items: {
         type: "array",
@@ -289,7 +469,7 @@ A custom Firebase event example for mobile apps.
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
         },
         event: {
           type: "string",
@@ -317,6 +497,51 @@ A custom Firebase event example for mobile apps.
             "Country code that must not be US (demo for not + const rendering).",
           not: { const: "US" },
           examples: ["DE"],
+        },
+        status_code: {
+          type: "string",
+          description:
+            "Complex not example: disallow success-like codes via nested anyOf.",
+          not: {
+            anyOf: [
+              { const: "200" },
+              { pattern: "^2[0-9]{2}$" },
+              { enum: ["ok", "success"] },
+            ],
+          },
+          examples: ["500"],
+        },
+        region_bucket: {
+          type: "string",
+          description:
+            "Complex not example: disallow restricted prefixes and exact values.",
+          not: {
+            anyOf: [
+              { pattern: "^internal-" },
+              { enum: ["private", "secret"] },
+              {
+                allOf: [
+                  { minLength: 2 },
+                  { maxLength: 2 },
+                  { pattern: "^[A-Z]{2}$" },
+                ],
+              },
+            ],
+          },
+          examples: ["public-west"],
+        },
+        sku: {
+          type: "string",
+          description:
+            "Complex not example: disallow short numeric-only IDs and known placeholders.",
+          not: {
+            anyOf: [
+              { pattern: "^[0-9]{1,4}$" },
+              { enum: ["unknown", "tbd", "na"] },
+              { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+            ],
+          },
+          examples: ["SKU-12345"],
         },
       },
       required: ["$schema", "event"],

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/index.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/index.mdx
@@ -111,7 +111,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/screen-view-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/screen-view-event.json",
         },
         event: {
           type: "string",
@@ -154,7 +154,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/login-with-user-properties-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/login-with-user-properties-event.json",
         },
         event: {
           type: "string",
@@ -251,7 +251,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",
@@ -356,7 +356,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-promotion-event.json",
         },
         event: {
           type: "string",
@@ -561,7 +561,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-promotion-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-promotion-event.json",
         },
         event: {
           type: "string",
@@ -614,7 +614,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-list-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-list-event.json",
         },
         event: {
           type: "string",
@@ -657,7 +657,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/select-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/select-item-event.json",
         },
         event: {
           type: "string",
@@ -700,7 +700,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-item-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-item-event.json",
         },
         event: {
           type: "string",
@@ -745,7 +745,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-wishlist-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-wishlist-event.json",
         },
         event: {
           type: "string",
@@ -790,7 +790,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-to-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-to-cart-event.json",
         },
         event: {
           type: "string",
@@ -835,7 +835,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/view-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/view-cart-event.json",
         },
         event: {
           type: "string",
@@ -880,7 +880,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/remove-from-cart-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/remove-from-cart-event.json",
         },
         event: {
           type: "string",
@@ -925,7 +925,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/begin-checkout-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/begin-checkout-event.json",
         },
         event: {
           type: "string",
@@ -976,7 +976,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-shipping-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-shipping-info-event.json",
         },
         event: {
           type: "string",
@@ -1032,7 +1032,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/add-payment-info-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/add-payment-info-event.json",
         },
         event: {
           type: "string",
@@ -1087,7 +1087,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/purchase-event.json",
         },
         event: {
           type: "string",
@@ -1169,7 +1169,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/refund-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/refund-event.json",
         },
         event: {
           type: "string",
@@ -1235,7 +1235,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/events/in-app-purchase-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/in-app-purchase-event.json",
         },
         event: {
           type: "string",
@@ -1311,7 +1311,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
         },
         event: {
           type: "string",

--- a/demo/versioned_docs/version-1.3.0/mobile-reference/index.mdx
+++ b/demo/versioned_docs/version-1.3.0/mobile-reference/index.mdx
@@ -204,6 +204,9 @@ Please select one of the following options:
     "mobile/checkout-options-event.json": {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       $id: "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+      $dynamicAnchor: "checkoutOptionsEvent",
+      $comment:
+        "Metadata example for the schema JSON viewer on a mobile event schema.",
       title: "Checkout Options",
       description:
         "Mobile checkout example with oneOf, anyOf, and platform-specific conditional fields using flat Firebase-compatible params.",
@@ -248,7 +251,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/checkout-options-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/checkout-options-event.json",
         },
         event: {
           type: "string",
@@ -1308,7 +1311,7 @@ Please select one of the following options:
           type: "string",
           description: "Defines the structure of the event.",
           const:
-            "https://tracking-docs-demo.buchert.digital/schemas/1.3.0/mobile/custom-event.json",
+            "https://tracking-docs-demo.buchert.digital/schemas/mobile/custom-event.json",
         },
         event: {
           type: "string",
@@ -1336,6 +1339,51 @@ Please select one of the following options:
             "Country code that must not be US (demo for not + const rendering).",
           not: { const: "US" },
           examples: ["DE"],
+        },
+        status_code: {
+          type: "string",
+          description:
+            "Complex not example: disallow success-like codes via nested anyOf.",
+          not: {
+            anyOf: [
+              { const: "200" },
+              { pattern: "^2[0-9]{2}$" },
+              { enum: ["ok", "success"] },
+            ],
+          },
+          examples: ["500"],
+        },
+        region_bucket: {
+          type: "string",
+          description:
+            "Complex not example: disallow restricted prefixes and exact values.",
+          not: {
+            anyOf: [
+              { pattern: "^internal-" },
+              { enum: ["private", "secret"] },
+              {
+                allOf: [
+                  { minLength: 2 },
+                  { maxLength: 2 },
+                  { pattern: "^[A-Z]{2}$" },
+                ],
+              },
+            ],
+          },
+          examples: ["public-west"],
+        },
+        sku: {
+          type: "string",
+          description:
+            "Complex not example: disallow short numeric-only IDs and known placeholders.",
+          not: {
+            anyOf: [
+              { pattern: "^[0-9]{1,4}$" },
+              { enum: ["unknown", "tbd", "na"] },
+              { allOf: [{ pattern: "^[A-Z0-9_-]+$" }, { maxLength: 3 }] },
+            ],
+          },
+          examples: ["SKU-12345"],
         },
       },
       required: ["$schema", "event"],

--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -171,6 +171,28 @@ When using the versioning feature, the plugin will automatically update the `$id
 
 This is done automatically by the plugin. However, if you need to update the `$id`s of your schemas manually, you can use the `update-schema-ids.js` script located in the plugin's `helpers` directory.
 
+### Versioning Commands
+
+- `docusaurus version-with-schemas <version>`
+  Creates a brand new Docusaurus docs version, copies `static/schemas/next` to `static/schemas/<version>`, updates schema `$id`s, and generates the versioned schema docs.
+- `docusaurus sync-version-from-next <version>`
+  Replaces an already existing `static/schemas/<version>` snapshot with the current `static/schemas/next` schemas, updates schema `$id`s, and regenerates the versioned schema docs for that existing version.
+
+### Scope of Plugin Version Sync
+
+The plugin's versioning commands only manage:
+
+- `static/schemas/next`
+- `static/schemas/<version>`
+- generated schema docs in `docs/` and `versioned_docs/version-<version>/`
+
+They do **not** attempt to sync or clean repo-specific manual content such as:
+
+- hand-maintained MDX pages
+- `partials/` content
+
+Those remain repository-level workflow concerns and should be copied or maintained explicitly when needed.
+
 ## Partials
 
 You can provide additional content to the generated documentation pages by creating partial files. Partials are Markdown files that can be automatically included in the generated pages.

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -25,6 +25,7 @@ jest.mock('fs', () => ({
   existsSync: jest.fn(),
   readFileSync: jest.fn(),
   cpSync: jest.fn(),
+  rmSync: jest.fn(),
 }));
 
 import generateEventDocs from '../generateEventDocs.js';
@@ -49,6 +50,13 @@ const makeOptions = () => ({ dataLayerName: 'dataLayer' });
 beforeEach(() => {
   jest.clearAllMocks();
   fs.existsSync.mockReturnValue(false);
+  fs.cpSync.mockImplementation(() => {});
+  fs.rmSync.mockImplementation(() => {});
+  execSync.mockImplementation(() => {});
+  getPathsForVersion.mockReturnValue({
+    schemaDir: '/site/static/schemas/next',
+    outputDir: '/site/docs',
+  });
 });
 
 describe('loadContent', () => {
@@ -370,6 +378,18 @@ describe('extendCli - version-with-schemas', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     // versions.json absent (not versioned); nextSchemasDir present
     fs.existsSync.mockImplementation((p) => !p.includes('versions.json'));
+    getPathsForVersion.mockImplementation((version) => {
+      if (version === '1.2.0') {
+        return {
+          schemaDir: '/site/static/schemas/1.2.0',
+          outputDir: '/site/versioned_docs/version-1.2.0',
+        };
+      }
+      return {
+        schemaDir: '/site/static/schemas/next',
+        outputDir: '/site/docs',
+      };
+    });
   });
 
   it('creates version, copies schemas, updates IDs and generates docs on success', async () => {
@@ -431,6 +451,95 @@ describe('extendCli - version-with-schemas', () => {
     await action('1.2.0');
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});
+
+describe('extendCli - sync-version-from-next', () => {
+  const getAction = async () => {
+    let captured = null;
+    const cli = {
+      command: jest.fn((name) => {
+        const cmd = {
+          description: jest.fn().mockReturnThis(),
+          option: jest.fn().mockReturnThis(),
+          action: jest.fn((fn) => {
+            if (name === 'sync-version-from-next <version>') captured = fn;
+            return cmd;
+          }),
+        };
+        return cmd;
+      }),
+    };
+    const plugin = await createPlugin(makeContext(), makeOptions());
+    plugin.extendCli(cli);
+    return captured;
+  };
+
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    fs.existsSync.mockImplementation((p) => p === '/site/versions.json');
+    fs.readFileSync.mockReturnValue(JSON.stringify(['1.2.0']));
+    getPathsForVersion.mockImplementation((version) => {
+      if (version === '1.2.0') {
+        return {
+          schemaDir: '/site/static/schemas/1.2.0',
+          outputDir: '/site/versioned_docs/version-1.2.0',
+        };
+      }
+      return {
+        schemaDir: '/site/static/schemas/next',
+        outputDir: '/site/docs',
+      };
+    });
+  });
+
+  it('syncs an existing version from next schemas without calling docs:version', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    fs.existsSync.mockImplementation(
+      (p) =>
+        p === '/site/versions.json' ||
+        p === '/site/static/schemas/next' ||
+        p === '/site/static/schemas/1.2.0' ||
+        p === '/site/versioned_docs/version-1.2.0',
+    );
+
+    const action = await getAction();
+    await action('1.2.0');
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(execSync).not.toHaveBeenCalled();
+    expect(fs.rmSync).toHaveBeenCalledWith('/site/static/schemas/1.2.0', {
+      recursive: true,
+      force: true,
+    });
+    expect(fs.cpSync).toHaveBeenCalledWith(
+      '/site/static/schemas/next',
+      '/site/static/schemas/1.2.0',
+      { recursive: true },
+    );
+    expect(updateSchemaIds).toHaveBeenCalledWith(
+      '/site',
+      'https://example.com',
+      '1.2.0',
+    );
+    expect(generateEventDocs).toHaveBeenCalledWith(
+      expect.objectContaining({ version: '1.2.0' }),
+    );
+    exitSpy.mockRestore();
+  });
+
+  it('exits with code 1 when the target version is not in versions.json', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    fs.readFileSync.mockReturnValue(JSON.stringify(['1.1.1']));
+
+    const action = await getAction();
+    await action('1.2.0');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.cpSync).not.toHaveBeenCalled();
+    expect(generateEventDocs).not.toHaveBeenCalled();
     exitSpy.mockRestore();
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -9,6 +9,66 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function readConfiguredVersions(siteDir) {
+  const versionsJsonPath = path.join(siteDir, 'versions.json');
+  if (!fs.existsSync(versionsJsonPath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(versionsJsonPath, 'utf8'));
+}
+
+async function syncVersionFromNext({
+  siteDir,
+  url,
+  version,
+  pluginOptions,
+  requireExistingVersion = false,
+}) {
+  if (requireExistingVersion) {
+    const versions = readConfiguredVersions(siteDir);
+    if (!versions) {
+      console.error('❌ Versioning is not enabled for this site.');
+      return false;
+    }
+
+    if (!versions.includes(version)) {
+      console.error(`❌ Version ${version} is not present in versions.json`);
+      return false;
+    }
+  }
+
+  const nextSchemasDir = path.join(siteDir, 'static/schemas/next');
+  const { schemaDir: versionedSchemasDir } = getPathsForVersion(
+    version,
+    siteDir,
+  );
+
+  if (!fs.existsSync(nextSchemasDir)) {
+    console.error(`❌ Source schemas directory not found: ${nextSchemasDir}`);
+    return false;
+  }
+
+  try {
+    if (fs.existsSync(versionedSchemasDir)) {
+      fs.rmSync(versionedSchemasDir, { recursive: true, force: true });
+    }
+    fs.cpSync(nextSchemasDir, versionedSchemasDir, { recursive: true });
+    console.log(`✅ Schemas copied to ${versionedSchemasDir}`);
+  } catch (error) {
+    console.error(`❌ Failed to copy schemas: ${error.message}`);
+    return false;
+  }
+
+  console.log(`🔄 Updating schema $ids for version ${version}...`);
+  updateSchemaIds(siteDir, url, version);
+
+  console.log(`📝 Generating documentation for version ${version}...`);
+  await generateEventDocs({ ...pluginOptions, version });
+
+  return true;
+}
+
 export default async function (context, options) {
   const { siteDir } = context;
   const { dataLayerName } = options;
@@ -118,36 +178,15 @@ export default async function (context, options) {
         }
 
         console.log(`📂 Copying schemas from next to ${version}...`);
-        const nextSchemasDir = path.join(siteDir, 'static/schemas/next');
-        const versionedSchemasDir = path.join(
+        const success = await syncVersionFromNext({
           siteDir,
-          'static/schemas',
+          url,
           version,
-        );
-
-        if (!fs.existsSync(nextSchemasDir)) {
-          console.error(
-            `❌ Source schemas directory not found: ${nextSchemasDir}`,
-          );
+          pluginOptions,
+        });
+        if (!success) {
           process.exit(1);
         }
-
-        // Copy the schemas
-        try {
-          fs.cpSync(nextSchemasDir, versionedSchemasDir, { recursive: true });
-          console.log(`✅ Schemas copied to ${versionedSchemasDir}`);
-        } catch (error) {
-          console.error(`❌ Failed to copy schemas: ${error.message}`);
-          process.exit(1);
-        }
-
-        // Update schema IDs for the new version
-        console.log(`🔄 Updating schema $ids for version ${version}...`);
-        updateSchemaIds(siteDir, url, version);
-
-        // Generate documentation for the new version
-        console.log(`📝 Generating documentation for version ${version}...`);
-        await generateEventDocs({ ...pluginOptions, version });
 
         console.log(`\n✅ Version ${version} created successfully!`);
         console.log(`\nNext steps:`);
@@ -156,6 +195,34 @@ export default async function (context, options) {
           `  2. Review the changes in versioned_docs/version-${version}/`,
         );
         console.log(`  3. Commit the changes to version control`);
+      });
+
+    cli
+      .command('sync-version-from-next <version>')
+      .description(
+        'Replace an existing versioned schema snapshot from static/schemas/next and regenerate its docs',
+      )
+      .action(async (version) => {
+        console.log(`🔄 Syncing version ${version} from next schemas...`);
+        const success = await syncVersionFromNext({
+          siteDir,
+          url,
+          version,
+          pluginOptions,
+          requireExistingVersion: true,
+        });
+        if (!success) {
+          process.exit(1);
+        }
+
+        console.log(`\n✅ Version ${version} synced successfully!`);
+        console.log(`\nNotes:`);
+        console.log(
+          '  - This command syncs schemas and regenerated docs only.',
+        );
+        console.log(
+          '  - Manual MDX pages and partials remain repo-level maintenance.',
+        );
       });
   };
 


### PR DESCRIPTION
## Summary
- add a sync-version-from-next command for existing version snapshots
- reuse the schema copy, $id rewrite, and docs regeneration flow behind version-with-schemas
- document that manual MDX pages and partials stay out of scope for plugin-managed version sync

## Testing
- npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js --runInBand
- npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.versioned.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/update-schema-ids.test.js --runInBand
- npm run docusaurus -- sync-version-from-next 1.3.0
- full pre-commit hooks (jest, validate-schemas, eslint)

Closes #125
Closes #126