### PR TITLE
Make tracking targets pluggable

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -30,6 +30,16 @@ npm install --save docusaurus-plugin-generate-schema-docs
           {
             // Options if any
             dataLayerName: 'customDataLayer',
+            trackingTargets: [
+              {
+                id: 'web-custom-js',
+                label: 'Custom Web',
+                language: 'javascript',
+                generateSnippet({ example }) {
+                  return `custom.track(${JSON.stringify(example.event)});`;
+                },
+              },
+            ],
           },
         ],
       ],
@@ -40,6 +50,41 @@ npm install --save docusaurus-plugin-generate-schema-docs
     The `dataLayerName` option allows you to customize the name of the data layer variable in the generated examples. If not provided, it defaults to `dataLayer`.
 
 2.  Place your JSON schemas in the `schemas` directory at the root of your project.
+
+## Custom Tracking Targets
+
+Use `trackingTargets` to add snippet targets that schemas can select with `x-tracking-targets`.
+
+```json
+{
+  "title": "Custom Event",
+  "type": "object",
+  "x-tracking-targets": ["web-custom-js"],
+  "properties": {
+    "event": { "type": "string", "const": "custom_event" }
+  }
+}
+```
+
+A target must define:
+
+```javascript
+{
+  id: 'web-custom-js',
+  label: 'Custom Web',
+  language: 'javascript',
+  generateSnippet({ example, schema, config, dataLayerName, targetId }) {
+    return `custom.track(${JSON.stringify(example.event)});`;
+  },
+  validateSchema(schema) {
+    return [];
+  },
+}
+```
+
+`id` must be unique across built-in and custom targets. `generateSnippet` runs during validation and documentation generation; generated MDX receives serialized snippets, not adapter functions.
+
+`validateSchema` is optional. Return an array of error messages, a single error string, `{ errors: [...] }`, or a falsy value when the schema is valid.
 
 ## CLI Commands
 

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/ExampleDataLayer.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/ExampleDataLayer.test.js
@@ -103,6 +103,44 @@ describe('ExampleDataLayer', () => {
     expect(getByText(/window.customDataLayer.push/)).toBeInTheDocument();
   });
 
+  it('renders a prebuilt example model when provided', () => {
+    const schema = {
+      type: 'object',
+      'x-tracking-targets': ['web-custom-js'],
+      properties: {
+        event: { type: 'string', examples: ['ignored_event'] },
+      },
+    };
+    const exampleModel = {
+      targets: [
+        {
+          id: 'web-custom-js',
+          label: 'Custom Web',
+          language: 'javascript',
+        },
+      ],
+      variantGroups: [
+        {
+          property: 'default',
+          options: [
+            {
+              id: 'default-0',
+              title: 'Default',
+              snippets: {
+                'web-custom-js': 'custom.track("custom_event");',
+              },
+            },
+          ],
+        },
+      ],
+      isSimpleDefault: true,
+    };
+
+    render(<ExampleDataLayer schema={schema} exampleModel={exampleModel} />);
+
+    expect(screen.getByText('custom.track("custom_event");')).toBeVisible();
+  });
+
   it('should render target tabs when multiple targets are configured', () => {
     const schema = {
       type: 'object',

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/SchemaViewer.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/SchemaViewer.test.js
@@ -41,4 +41,43 @@ describe('SchemaViewer', () => {
     // There should be at least 3 required constraints visible at the top level.
     expect(requiredConstraints.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('passes a prebuilt example model to the example renderer', () => {
+    const schema = {
+      title: 'Custom Target Event',
+      type: 'object',
+      'x-tracking-targets': ['web-custom-js'],
+      properties: {
+        event: { type: 'string', examples: ['ignored_event'] },
+      },
+    };
+    const exampleModel = {
+      targets: [
+        {
+          id: 'web-custom-js',
+          label: 'Custom Web',
+          language: 'javascript',
+        },
+      ],
+      variantGroups: [
+        {
+          property: 'default',
+          options: [
+            {
+              id: 'default-0',
+              title: 'Default',
+              snippets: {
+                'web-custom-js': 'custom.track("custom_event");',
+              },
+            },
+          ],
+        },
+      ],
+      isSimpleDefault: true,
+    };
+
+    render(<SchemaViewer schema={schema} exampleModel={exampleModel} />);
+
+    expect(screen.getByText('custom.track("custom_event");')).toBeVisible();
+  });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
@@ -97,6 +97,54 @@ describe('generateEventDocs (non-versioned)', () => {
       'custom_edit_url: https://github.com/test-org/test-project/edit/main/__fixtures__/static/schemas/root-choice-event.json',
     );
   });
+
+  it('embeds a prebuilt example model for configured custom tracking targets', async () => {
+    console.log = jest.fn();
+    const schemaDir = path.join(options.siteDir, 'static/schemas');
+    fs.writeFileSync(
+      path.join(schemaDir, 'custom-target-event.json'),
+      JSON.stringify(
+        {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/schemas/custom-target-event.json',
+          title: 'Custom Target Event',
+          description: 'An event rendered with a custom target.',
+          type: 'object',
+          'x-tracking-targets': ['web-custom-js'],
+          required: ['event'],
+          properties: {
+            event: {
+              type: 'string',
+              const: 'custom_event',
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await generateEventDocs({
+      ...options,
+      trackingTargets: [
+        {
+          id: 'web-custom-js',
+          label: 'Custom Web',
+          language: 'javascript',
+          generateSnippet: ({ example }) =>
+            `custom.track(${JSON.stringify(example.event)});`,
+        },
+      ],
+    });
+
+    const customTargetDoc = fs.readFileSync(
+      path.join(outputDir, 'custom-target-event.mdx'),
+      'utf-8',
+    );
+    expect(customTargetDoc).toContain('exampleModel={');
+    expect(customTargetDoc).toContain('"id":"web-custom-js"');
+    expect(customTargetDoc).toContain('custom.track(\\"custom_event\\");');
+  });
 });
 
 describe('generateEventDocs (edge cases)', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/exampleModel.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/exampleModel.test.js
@@ -2,7 +2,10 @@ import {
   buildExampleModel,
   resolveExampleTargets,
 } from '../../helpers/exampleModel';
-import { DEFAULT_SNIPPET_TARGET_ID } from '../../helpers/snippetTargets';
+import {
+  createTrackingTargetRegistry,
+  DEFAULT_SNIPPET_TARGET_ID,
+} from '../../helpers/snippetTargets';
 import choiceEventSchema from '../__fixtures__/static/schemas/choice-event.json';
 import conditionalEventSchema from '../__fixtures__/static/schemas/conditional-event.json';
 
@@ -115,6 +118,35 @@ describe('buildExampleModel', () => {
     expect(
       model.variantGroups[0].options[0].snippets[DEFAULT_SNIPPET_TARGET_ID],
     ).toContain('window.customDataLayer.push');
+  });
+
+  it('builds snippets for custom targets from a tracking target registry', () => {
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          generateSnippet: ({ example }) =>
+            `custom.track(${JSON.stringify(example.event)});`,
+        },
+      ],
+    });
+    const schema = {
+      'x-tracking-targets': ['web-custom-js'],
+      type: 'object',
+      properties: {
+        event: { type: 'string', examples: ['custom_event'] },
+      },
+    };
+
+    const model = buildExampleModel(schema, { targetRegistry });
+
+    expect(model.targets.map((target) => target.id)).toEqual(['web-custom-js']);
+    expect(model.variantGroups[0].options[0].snippets['web-custom-js']).toBe(
+      'custom.track("custom_event");',
+    );
   });
 
   it('resolves multiple targets when x-tracking-targets is provided', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
@@ -1,4 +1,5 @@
 import {
+  createTrackingTargetRegistry,
   DEFAULT_SNIPPET_TARGET_ID,
   generateSnippetForTarget,
   getSnippetTarget,
@@ -26,6 +27,26 @@ describe('snippetTargets', () => {
         'ios-firebase-objc-sdk',
       ]),
     );
+  });
+
+  it('exposes generateSnippet as the single target snippet API', () => {
+    SNIPPET_TARGETS.forEach((target) => {
+      expect(target.generateSnippet).toEqual(expect.any(Function));
+      expect(target).not.toHaveProperty('generator');
+    });
+  });
+
+  it('rejects custom targets that use the legacy generator API', () => {
+    expect(() =>
+      createTrackingTargetRegistry({
+        customTargets: [
+          {
+            id: 'web-legacy-js',
+            generator: () => 'legacy.track();',
+          },
+        ],
+      }),
+    ).toThrow('Tracking target "web-legacy-js" must define generateSnippet.');
   });
 
   it('resolves the default target when no id is provided', () => {
@@ -1107,7 +1128,7 @@ describe('snippetTargets', () => {
   // L222: config default-arg — call web generator directly without config
   it('web generator defaults config to {} when config is omitted', () => {
     const webTarget = SNIPPET_TARGETS.find((t) => t.id === 'web-datalayer-js');
-    const snippet = webTarget.generator({
+    const snippet = webTarget.generateSnippet({
       example: { event: 'test_event' },
       schema: { properties: {} },
       dataLayerName: 'myDL',
@@ -1119,7 +1140,7 @@ describe('snippetTargets', () => {
   // L227: schema || {} — call web generator with schema undefined
   it('web generator falls back to empty schema when schema is falsy', () => {
     const webTarget = SNIPPET_TARGETS.find((t) => t.id === 'web-datalayer-js');
-    const snippet = webTarget.generator({
+    const snippet = webTarget.generateSnippet({
       example: { event: 'test_event' },
       schema: undefined,
       config: {},
@@ -1136,7 +1157,7 @@ describe('snippetTargets', () => {
     );
     // example with only event triggers toFirebaseParamEntries with a truthy example
     // but no additional params — the || {} fallback is defensive
-    const snippet = kotlinTarget.generator({
+    const snippet = kotlinTarget.generateSnippet({
       example: { event: 'simple_event' },
       targetId: 'android-firebase-kotlin-sdk',
     });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/trackingTargets.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/trackingTargets.test.js
@@ -3,6 +3,7 @@ import {
   resolveTrackingTargets,
   resolveCallMethod,
 } from '../../helpers/trackingTargets';
+import { createTrackingTargetRegistry } from '../../helpers/snippetTargets';
 
 describe('trackingTargets', () => {
   it('returns the configured targets when valid', () => {
@@ -144,6 +145,34 @@ describe('trackingTargets', () => {
     expect(result.targets).toEqual([]);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('web-not-supported-js');
+  });
+
+  it('accepts custom targets from a tracking target registry', () => {
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          generateSnippet: () => 'custom.track();',
+        },
+      ],
+    });
+    const schema = {
+      'x-tracking-targets': ['web-custom-js'],
+    };
+
+    const result = resolveTrackingTargets(schema, {
+      schemaFile: 'event.json',
+      targetRegistry,
+    });
+
+    expect(result).toEqual({
+      targets: ['web-custom-js'],
+      warning: null,
+      errors: [],
+    });
   });
 
   it('joins multiple unsupported targets with comma-space formatting', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -45,7 +45,17 @@ const makeContext = (overrides = {}) => ({
   ...overrides,
 });
 
-const makeOptions = () => ({ dataLayerName: 'dataLayer' });
+const makeOptions = (overrides = {}) => ({
+  dataLayerName: 'dataLayer',
+  ...overrides,
+});
+
+const makeCustomTarget = () => ({
+  id: 'web-custom-js',
+  label: 'Custom Web',
+  language: 'javascript',
+  generateSnippet: jest.fn(() => 'custom.track();'),
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -119,7 +129,10 @@ describe('extendCli - validate-schemas', () => {
     expect(cli.command).toHaveBeenCalledWith('validate-schemas [version]');
     await action.fn('next');
 
-    expect(validateSchemas).toHaveBeenCalledWith('/site/static/schemas/next');
+    expect(validateSchemas).toHaveBeenCalledWith(
+      '/site/static/schemas/next',
+      expect.objectContaining({ targetRegistry: expect.any(Object) }),
+    );
   });
 
   it('defaults to "next" version when no version argument given', async () => {
@@ -129,7 +142,25 @@ describe('extendCli - validate-schemas', () => {
 
     await action.fn(undefined);
     expect(getPathsForVersion).toHaveBeenCalledWith('next', '/site');
-    expect(validateSchemas).toHaveBeenCalledWith('/site/static/schemas/next');
+    expect(validateSchemas).toHaveBeenCalledWith(
+      '/site/static/schemas/next',
+      expect.objectContaining({ targetRegistry: expect.any(Object) }),
+    );
+  });
+
+  it('configures schema validation with custom tracking targets', async () => {
+    const customTarget = makeCustomTarget();
+    const { cli, action } = makeCli();
+    const plugin = await createPlugin(
+      makeContext(),
+      makeOptions({ trackingTargets: [customTarget] }),
+    );
+    plugin.extendCli(cli);
+
+    await action.fn('next');
+
+    const targetRegistry = validateSchemas.mock.calls[0][1].targetRegistry;
+    expect(targetRegistry.has('web-custom-js')).toBe(true);
   });
 
   it('exits with code 1 when validation fails', async () => {
@@ -165,6 +196,21 @@ describe('plugin structure', () => {
         siteDir: '/site',
         url: 'https://example.com',
         dataLayerName: 'dataLayer',
+      }),
+    );
+  });
+
+  it('passes configured tracking targets to generateEventDocs', async () => {
+    const customTarget = makeCustomTarget();
+    const plugin = await createPlugin(
+      makeContext(),
+      makeOptions({ trackingTargets: [customTarget] }),
+    );
+    await plugin.loadContent();
+
+    expect(generateEventDocs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trackingTargets: [customTarget],
       }),
     );
   });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
@@ -6,6 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import validateSchemas from '../validateSchemas';
+import { createTrackingTargetRegistry } from '../helpers/snippetTargets';
 
 describe('validateSchemas', () => {
   let tmpDir;
@@ -101,6 +102,84 @@ describe('validateSchemas', () => {
     expect(result).toBe(false);
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(consoleErrorSpy.mock.calls[0][0]).toContain('x-tracking-targets');
+  });
+
+  it('should accept custom targets from a tracking target registry', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          generateSnippet: () => 'custom.track();',
+        },
+      ],
+    });
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        'x-tracking-targets': ['web-custom-js'],
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir, { targetRegistry });
+
+    expect(result).toBe(true);
+  });
+
+  it('should fail when a custom target validation hook reports errors', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          validateSchema: (schema) =>
+            schema['x-custom-required']
+              ? []
+              : ['x-custom-required must be true.'],
+          generateSnippet: () => 'custom.track();',
+        },
+      ],
+    });
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        'x-tracking-targets': ['web-custom-js'],
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir, { targetRegistry });
+
+    expect(result).toBe(false);
+    const errorMessages = consoleErrorSpy.mock.calls
+      .map((c) => c[0])
+      .join('\n');
+    expect(errorMessages).toContain('x-custom-required must be true.');
   });
 
   it('should treat falsy scalar examples as valid examples', async () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/components/ExampleDataLayer.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/ExampleDataLayer.js
@@ -65,10 +65,14 @@ function resolveInitialTargetId(targets) {
   return safeTargets[0].id;
 }
 
-export default function ExampleDataLayer({ schema, dataLayerName }) {
+export default function ExampleDataLayer({
+  schema,
+  dataLayerName,
+  exampleModel,
+}) {
   const model = useMemo(
-    () => buildExampleModel(schema, { dataLayerName }),
-    [schema, dataLayerName],
+    () => exampleModel || buildExampleModel(schema, { dataLayerName }),
+    [schema, dataLayerName, exampleModel],
   );
   const safeTargets = useMemo(
     () =>

--- a/packages/docusaurus-plugin-generate-schema-docs/components/SchemaViewer.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/SchemaViewer.js
@@ -9,6 +9,7 @@ export default function SchemaViewer({
   sourcePath,
   schemaSources,
   dataLayerName,
+  exampleModel,
 }) {
   const resolvedSourceSchema =
     (sourcePath && schemaSources?.[sourcePath]) || sourceSchema || schema;
@@ -29,7 +30,11 @@ export default function SchemaViewer({
   return (
     <div>
       <Heading as="h2">{exampleTitle}</Heading>
-      <ExampleDataLayer schema={schema} dataLayerName={dataLayerName} />
+      <ExampleDataLayer
+        schema={schema}
+        dataLayerName={dataLayerName}
+        exampleModel={exampleModel}
+      />
 
       <Heading as="h2">Event Properties</Heading>
       <PropertiesTable schema={schema} sourceSchema={resolvedSourceSchema} />

--- a/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
@@ -11,6 +11,8 @@ import { processOneOfSchema } from './helpers/schema-processing.js';
 import SchemaDocTemplate from './helpers/schema-doc-template.js';
 import ChoiceIndexTemplate from './helpers/choice-index-template.js';
 import processSchema from './helpers/processSchema.js';
+import { buildExampleModel } from './helpers/exampleModel.js';
+import { createTrackingTargetRegistry } from './helpers/snippetTargets.js';
 
 function buildEditUrl(organizationName, projectName, siteDir, filePath) {
   const baseEditUrl = `https://github.com/${organizationName}/${projectName}/edit/main`;
@@ -152,8 +154,14 @@ async function generateAndWriteDoc(
   schemaSources = {},
   schemaDir,
 ) {
-  const { organizationName, projectName, siteDir, dataLayerName, version } =
-    options;
+  const {
+    organizationName,
+    projectName,
+    siteDir,
+    dataLayerName,
+    version,
+    targetRegistry,
+  } = options;
 
   const { outputDir: versionOutputDir } = getPathsForVersion(version, siteDir);
   const PARTIALS_DIR = path.join(versionOutputDir, 'partials');
@@ -165,6 +173,9 @@ async function generateAndWriteDoc(
   const allowBasenameFallback = !partialNameConflicts.has(eventName);
 
   const mergedSchema = alreadyMergedSchema || (await processSchema(filePath));
+  const exampleModel = targetRegistry
+    ? buildExampleModel(schema, { dataLayerName, targetRegistry })
+    : null;
 
   // Resolve scoped partials first; basename fallback is disabled for ambiguous names.
   const top = resolvePartial({
@@ -199,6 +210,7 @@ async function generateAndWriteDoc(
     topPartialComponent: top.component,
     bottomPartialComponent: bottom.component,
     dataLayerName,
+    exampleModel,
     sourcePath: toSchemaSourceKey(schemaDir, editFilePath || filePath),
     schemaSources: collectReachableSchemaSources(
       toSchemaSourceKey(schemaDir, editFilePath || filePath),
@@ -302,6 +314,17 @@ async function generateOneOfDocs(
 
 export default async function generateEventDocs(options) {
   const { siteDir, version, url } = options || {};
+  const trackingTargets = Array.isArray(options?.trackingTargets)
+    ? options.trackingTargets
+    : [];
+  const targetRegistry =
+    options?.targetRegistry ||
+    (trackingTargets.length > 0
+      ? createTrackingTargetRegistry({ customTargets: trackingTargets })
+      : null);
+  const generationOptions = targetRegistry
+    ? { ...options, targetRegistry }
+    : options;
   const { schemaDir, outputDir } = getPathsForVersion(version, siteDir);
 
   createDir(outputDir);
@@ -329,7 +352,7 @@ export default async function generateEventDocs(options) {
         schema,
         filePath,
         outputDir,
-        options,
+        generationOptions,
         partialNameConflicts,
         schemaSources,
         schemaDir,
@@ -340,7 +363,7 @@ export default async function generateEventDocs(options) {
         schema,
         eventName,
         outputDir,
-        options,
+        generationOptions,
         null,
         null,
         partialNameConflicts,

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/exampleModel.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/exampleModel.js
@@ -1,12 +1,17 @@
 import { schemaToExamples } from './schemaToExamples';
 import {
+  createTrackingTargetRegistry,
   DEFAULT_SNIPPET_TARGET_ID,
   findClearableProperties,
   generateSnippetForTarget,
-  getSnippetTarget,
 } from './snippetTargets';
 
-export function resolveExampleTargets(schema) {
+const DEFAULT_TARGET_REGISTRY = createTrackingTargetRegistry();
+
+export function resolveExampleTargets(
+  schema,
+  { targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+) {
   const configured = schema?.['x-tracking-targets'];
   const targetIds =
     Array.isArray(configured) && configured.length > 0
@@ -16,7 +21,7 @@ export function resolveExampleTargets(schema) {
   const targets = targetIds
     .map((id) => {
       try {
-        return getSnippetTarget(id);
+        return targetRegistry.get(id);
       } catch {
         return null;
       }
@@ -24,12 +29,15 @@ export function resolveExampleTargets(schema) {
     .filter(Boolean);
 
   if (targets.length > 0) return targets;
-  return [getSnippetTarget(DEFAULT_SNIPPET_TARGET_ID)];
+  return [targetRegistry.get(DEFAULT_SNIPPET_TARGET_ID)];
 }
 
-export function buildExampleModel(schema, { dataLayerName } = {}) {
+export function buildExampleModel(
+  schema,
+  { dataLayerName, targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+) {
   const exampleGroups = schemaToExamples(schema);
-  const targets = resolveExampleTargets(schema);
+  const targets = resolveExampleTargets(schema, { targetRegistry });
 
   if (!exampleGroups || exampleGroups.length === 0) {
     return {
@@ -53,6 +61,7 @@ export function buildExampleModel(schema, { dataLayerName } = {}) {
             example: option.example,
             schema,
             dataLayerName,
+            targetRegistry,
           }),
         ]),
       ),

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/schema-doc-template.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/schema-doc-template.js
@@ -9,10 +9,17 @@ export default function MdxTemplate(data) {
     topPartialComponent,
     bottomPartialComponent,
     dataLayerName,
+    exampleModel,
     sourcePath,
     schemaSources,
   } = data;
   const sourceSchema = schemaSources?.[sourcePath] || schema;
+  const schemaViewerOptionLines = [
+    dataLayerName ? `dataLayerName={'${dataLayerName}'}` : null,
+    exampleModel ? `exampleModel={${JSON.stringify(exampleModel)}}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n  ');
 
   return `---
 title: ${schema.title}
@@ -37,7 +44,7 @@ ${topPartialComponent}
   sourceSchema={${JSON.stringify(sourceSchema)}}
   sourcePath={${JSON.stringify(sourcePath)}}
   schemaSources={${JSON.stringify(schemaSources)}}
-  ${dataLayerName ? ` dataLayerName={'${dataLayerName}'}` : ''}
+  ${schemaViewerOptionLines}
 />
 <SchemaJsonViewer
   schema={${JSON.stringify(schema)}}

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
@@ -864,75 +864,70 @@ export const SNIPPET_TARGETS = [
     group: 'web',
     label: 'Web Data Layer (JS)',
     language: 'javascript',
-    generator: generateWebDataLayerSnippet,
+    generateSnippet: generateWebDataLayerSnippet,
   },
   {
     id: 'android-firebase-kotlin-sdk',
     group: 'android',
     label: 'Android Firebase (Kotlin)',
     language: 'kotlin',
-    generator: generateAndroidKotlinFirebaseSnippet,
+    generateSnippet: generateAndroidKotlinFirebaseSnippet,
   },
   {
     id: 'android-firebase-java-sdk',
     group: 'android',
     label: 'Android Firebase (Java)',
     language: 'java',
-    generator: generateAndroidJavaFirebaseSnippet,
+    generateSnippet: generateAndroidJavaFirebaseSnippet,
   },
   {
     id: 'ios-firebase-swift-sdk',
     group: 'ios',
     label: 'iOS Firebase (Swift)',
     language: 'swift',
-    generator: generateIosSwiftFirebaseSnippet,
+    generateSnippet: generateIosSwiftFirebaseSnippet,
   },
   {
     id: 'ios-firebase-objc-sdk',
     group: 'ios',
     label: 'iOS Firebase (Obj-C)',
     language: 'objectivec',
-    generator: generateIosObjcFirebaseSnippet,
+    generateSnippet: generateIosObjcFirebaseSnippet,
   },
   {
     id: 'web-segment-js',
     group: 'web',
     label: 'Segment (JS)',
     language: 'javascript',
-    generator: generateCdpSnippet('analytics'),
+    generateSnippet: generateCdpSnippet('analytics'),
   },
   {
     id: 'web-rudderstack-js',
     group: 'web',
     label: 'RudderStack (JS)',
     language: 'javascript',
-    generator: generateCdpSnippet('rudderanalytics'),
+    generateSnippet: generateCdpSnippet('rudderanalytics'),
   },
   {
     id: 'web-hightouch-js',
     group: 'web',
     label: 'Hightouch (JS)',
     language: 'javascript',
-    generator: generateCdpSnippet('htevents'),
+    generateSnippet: generateCdpSnippet('htevents'),
   },
 ];
 
 function normalizeTrackingTarget(target) {
-  const generateSnippet = target?.generateSnippet || target?.generator;
   if (!target?.id || typeof target.id !== 'string') {
     throw new Error('Tracking target must define a string id.');
   }
-  if (typeof generateSnippet !== 'function') {
+  if (typeof target.generateSnippet !== 'function') {
     throw new Error(
       `Tracking target "${target.id}" must define generateSnippet.`,
     );
   }
 
-  return {
-    ...target,
-    generator: generateSnippet,
-    generateSnippet,
-  };
+  return target;
 }
 
 export function createTrackingTargetRegistry({ customTargets = [] } = {}) {

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
@@ -917,12 +917,84 @@ export const SNIPPET_TARGETS = [
   },
 ];
 
-export function getSnippetTarget(targetId = DEFAULT_SNIPPET_TARGET_ID) {
-  const target = SNIPPET_TARGETS.find((item) => item.id === targetId);
-  if (!target) {
+function normalizeTrackingTarget(target) {
+  const generateSnippet = target?.generateSnippet || target?.generator;
+  if (!target?.id || typeof target.id !== 'string') {
+    throw new Error('Tracking target must define a string id.');
+  }
+  if (typeof generateSnippet !== 'function') {
+    throw new Error(
+      `Tracking target "${target.id}" must define generateSnippet.`,
+    );
+  }
+
+  return {
+    ...target,
+    generator: generateSnippet,
+    generateSnippet,
+  };
+}
+
+export function createTrackingTargetRegistry({ customTargets = [] } = {}) {
+  const targets = [...SNIPPET_TARGETS, ...customTargets].map(
+    normalizeTrackingTarget,
+  );
+  const targetMap = new Map();
+
+  targets.forEach((target) => {
+    if (targetMap.has(target.id)) {
+      throw new Error(`Duplicate tracking target id: ${target.id}`);
+    }
+    targetMap.set(target.id, target);
+  });
+
+  return {
+    get(targetId = DEFAULT_SNIPPET_TARGET_ID) {
+      const target = targetMap.get(targetId);
+      if (!target) {
+        throw new Error(`Unknown snippet target: ${targetId}`);
+      }
+      return target;
+    },
+    has(targetId) {
+      return targetMap.has(targetId);
+    },
+    ids() {
+      return [...targetMap.keys()];
+    },
+    list() {
+      return [...targetMap.values()];
+    },
+    generateSnippet({
+      targetId = DEFAULT_SNIPPET_TARGET_ID,
+      example,
+      schema,
+      config = {},
+      dataLayerName,
+    }) {
+      const target = this.get(targetId);
+      return target.generateSnippet({
+        example,
+        schema,
+        config,
+        dataLayerName,
+        targetId,
+      });
+    },
+  };
+}
+
+const DEFAULT_TRACKING_TARGET_REGISTRY = createTrackingTargetRegistry();
+
+export function getSnippetTarget(
+  targetId = DEFAULT_SNIPPET_TARGET_ID,
+  targetRegistry = DEFAULT_TRACKING_TARGET_REGISTRY,
+) {
+  try {
+    return targetRegistry.get(targetId);
+  } catch {
     throw new Error(`Unknown snippet target: ${targetId}`);
   }
-  return target;
 }
 
 export function generateSnippetForTarget({
@@ -931,13 +1003,13 @@ export function generateSnippetForTarget({
   schema,
   config = {},
   dataLayerName,
+  targetRegistry = DEFAULT_TRACKING_TARGET_REGISTRY,
 }) {
-  const target = getSnippetTarget(targetId);
-  return target.generator({
+  return targetRegistry.generateSnippet({
+    targetId,
     example,
     schema,
     config,
     dataLayerName,
-    targetId,
   });
 }

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/trackingTargets.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/trackingTargets.js
@@ -1,15 +1,13 @@
-export const DEFAULT_TRACKING_TARGET = 'web-datalayer-js';
+import {
+  createTrackingTargetRegistry,
+  DEFAULT_SNIPPET_TARGET_ID,
+} from './snippetTargets.js';
 
-export const SUPPORTED_TRACKING_TARGETS = [
-  DEFAULT_TRACKING_TARGET,
-  'android-firebase-kotlin-sdk',
-  'android-firebase-java-sdk',
-  'ios-firebase-swift-sdk',
-  'ios-firebase-objc-sdk',
-  'web-segment-js',
-  'web-rudderstack-js',
-  'web-hightouch-js',
-];
+const DEFAULT_TARGET_REGISTRY = createTrackingTargetRegistry();
+
+export const DEFAULT_TRACKING_TARGET = DEFAULT_SNIPPET_TARGET_ID;
+
+export const SUPPORTED_TRACKING_TARGETS = DEFAULT_TARGET_REGISTRY.ids();
 
 const TARGET_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+){2,}$/;
 
@@ -66,7 +64,11 @@ function isReferenceAggregatorSchema(schema) {
 
 export function resolveTrackingTargets(
   schema,
-  { schemaFile = 'schema', isQuiet = false } = {},
+  {
+    schemaFile = 'schema',
+    isQuiet = false,
+    targetRegistry = DEFAULT_TARGET_REGISTRY,
+  } = {},
 ) {
   const configuredTargets = schema?.['x-tracking-targets'];
 
@@ -98,7 +100,7 @@ export function resolveTrackingTargets(
 
   const errors = [];
   const unknownTargets = configuredTargets.filter(
-    (target) => !SUPPORTED_TRACKING_TARGETS.includes(target),
+    (target) => !targetRegistry.has(target),
   );
 
   if (unknownTargets.length > 0) {

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -6,6 +6,7 @@ import generateEventDocs from './generateEventDocs.js';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { createTrackingTargetRegistry } from './helpers/snippetTargets.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -71,8 +72,11 @@ async function syncVersionFromNext({
 
 export default async function (context, options) {
   const { siteDir } = context;
-  const { dataLayerName } = options;
+  const { dataLayerName, trackingTargets = [] } = options || {};
   const { organizationName, projectName, url } = context.siteConfig;
+  const targetRegistry = createTrackingTargetRegistry({
+    customTargets: trackingTargets,
+  });
 
   const pluginOptions = {
     organizationName,
@@ -80,6 +84,7 @@ export default async function (context, options) {
     siteDir,
     url,
     dataLayerName,
+    trackingTargets,
   };
   const versionsJsonPath = path.join(siteDir, 'versions.json');
   const isVersioned = fs.existsSync(versionsJsonPath);
@@ -95,7 +100,7 @@ export default async function (context, options) {
           schemaVersion,
           context.siteDir,
         );
-        const success = await validateSchemas(schemaDir);
+        const success = await validateSchemas(schemaDir, { targetRegistry });
         if (!success) {
           console.error('Validation failed.');
           process.exit(1);

--- a/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
@@ -7,8 +7,37 @@ import {
   resolveTrackingTargets,
   resolveCallMethod,
 } from './helpers/trackingTargets.js';
+import { createTrackingTargetRegistry } from './helpers/snippetTargets.js';
 
-const validateSingleSchema = async (filePath, schemaPath) => {
+const DEFAULT_TARGET_REGISTRY = createTrackingTargetRegistry();
+
+function normalizeTargetValidationErrors(result) {
+  if (!result) return [];
+  if (Array.isArray(result)) return result;
+  if (typeof result === 'string') return [result];
+  if (Array.isArray(result.errors)) return result.errors;
+  return [];
+}
+
+function validateTrackingTargetHooks({
+  trackingTargets,
+  targetRegistry,
+  schema,
+}) {
+  return trackingTargets.targets.flatMap((targetId) => {
+    const target = targetRegistry.get(targetId);
+    if (typeof target.validateSchema !== 'function') return [];
+    return normalizeTargetValidationErrors(target.validateSchema(schema)).map(
+      (error) => `[${targetId}] ${error}`,
+    );
+  });
+}
+
+const validateSingleSchema = async (
+  filePath,
+  schemaPath,
+  { targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+) => {
   const file = path.basename(filePath);
   const errors = [];
   let allValid = true;
@@ -19,6 +48,7 @@ const validateSingleSchema = async (filePath, schemaPath) => {
     const originalSchema = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
     const trackingTargets = resolveTrackingTargets(originalSchema, {
       schemaFile: file,
+      targetRegistry,
     });
 
     if (trackingTargets.warning) {
@@ -28,6 +58,15 @@ const validateSingleSchema = async (filePath, schemaPath) => {
       trackingTargets.errors.forEach((error) =>
         errors.push(`x Schema ${file} ${error}`),
       );
+      return { allValid: false, errors };
+    }
+
+    validateTrackingTargetHooks({
+      trackingTargets,
+      targetRegistry,
+      schema: originalSchema,
+    }).forEach((error) => errors.push(`x Schema ${file} ${error}`));
+    if (errors.length > 0) {
       return { allValid: false, errors };
     }
 
@@ -89,7 +128,10 @@ const validateSingleSchema = async (filePath, schemaPath) => {
   return { allValid, errors };
 };
 
-const validateSchemas = async (schemaPath) => {
+const validateSchemas = async (
+  schemaPath,
+  { targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+) => {
   const topLevelSchemaFiles = fs
     .readdirSync(schemaPath)
     .filter((file) => file.endsWith('.json'));
@@ -97,7 +139,7 @@ const validateSchemas = async (schemaPath) => {
   const results = await Promise.all(
     topLevelSchemaFiles.map((file) => {
       const filePath = path.join(schemaPath, file);
-      return validateSingleSchema(filePath, schemaPath);
+      return validateSingleSchema(filePath, schemaPath, { targetRegistry });
     }),
   );
 


### PR DESCRIPTION
Summary:
- Add a tracking target registry for built-in and custom snippet targets.
- Use a single generateSnippet adapter API and reject legacy generator-shaped targets.
- Wire plugin trackingTargets options into validation and generated docs.
- Prebuild custom target example snippets at generation time so adapter functions stay server-side.
- Document the custom tracking target adapter contract.

Testing:
- Commit hooks passed dependency spec check, Jest, demo schema validation, and ESLint.
- Latest full hook run: 53 Jest suites, 912 tests, 20 snapshots.