### PR TITLE
fix: unwrap nested properties in PHP RudderStack track snippet

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
@@ -1592,6 +1592,24 @@ describe('server-rudderstack-php snippet', () => {
       );
     });
 
+    it('unwraps a nested properties object instead of double-nesting it', () => {
+      const snippet = generateSnippetForTarget({
+        targetId: 'server-rudderstack-php',
+        example: {
+          userId: '12345',
+          event: 'website_builder.chat_message_sent',
+          properties: {
+            website_category: 'Restaurant',
+            website_category_changed: true,
+          },
+        },
+        schema: {},
+      });
+      expect(snippet).toBe(
+        `Rudder::track([\n    'userId' => '12345',\n    'event' => 'website_builder.chat_message_sent',\n    'properties' => [\n        'website_category' => 'Restaurant',\n        'website_category_changed' => true,\n    ],\n]);`,
+      );
+    });
+
     it('throws when userId is missing', () => {
       expect(() =>
         generateSnippetForTarget({

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/snippetTargets.js
@@ -962,7 +962,11 @@ function generatePhpRudderstackSnippet({ example, schema, targetId }) {
   }
 
   if (method === 'track') {
-    const props = cdpProperties(example, new Set(['userId', 'event']));
+    const remaining = cdpProperties(example, new Set(['userId', 'event']));
+    const { properties: nestedProps, ...otherRemaining } = remaining;
+    const props = isPlainObject(nestedProps)
+      ? { ...nestedProps, ...otherRemaining }
+      : remaining;
     const lines = [
       `    'userId' => '${example.userId}'`,
       `    'event' => '${example.event}'`,


### PR DESCRIPTION
## Summary

- When a schema models event properties under a `properties` key (standard JSON Schema structure), the PHP RudderStack snippet generator was wrapping them under a second `'properties'` key, producing incorrect double-nesting like `'properties' => ['properties' => [...]]`
- Fixed by unwrapping the `properties` key when its value is a plain object, so the contents go directly into the PHP `'properties'` array
- Added a regression test that reproduces the exact case before fixing

## Test plan

- [ ] New test `unwraps a nested properties object instead of double-nesting it` confirms the bug and the fix
- [ ] All 944 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)