### PR TITLE
fix: Capture enum constraints on array items

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/getConstraints.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/getConstraints.test.js
@@ -143,4 +143,70 @@ describe('getConstraints', () => {
       'not: { items: [{ type: "string" }, { type: "number" }] }',
     ]);
   });
+
+  it('should prefix constraints from scalar array items with "items."', () => {
+    const prop = {
+      type: 'array',
+      items: {
+        enum: ['newsmail', 'engagement', 'customerPanel'],
+      },
+    };
+    expect(getConstraints(prop, false)).toEqual([
+      'items.enum: [newsmail, engagement, customerPanel]',
+    ]);
+  });
+
+  it('should prefix non-enum item constraints with "items."', () => {
+    const prop = {
+      type: 'array',
+      items: { type: 'string', minLength: 3 },
+    };
+    expect(getConstraints(prop, false)).toEqual(['items.minLength: 3']);
+  });
+
+  it('should keep array-level and item-level constraints distinguishable', () => {
+    const prop = {
+      type: 'array',
+      minItems: 1,
+      default: [],
+      items: { type: 'string', default: 'a' },
+    };
+    expect(getConstraints(prop, false)).toEqual([
+      'minItems: 1',
+      'default: []',
+      'items.default: "a"',
+    ]);
+  });
+
+  it('should not emit item constraints when items are objects with properties', () => {
+    const prop = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        additionalProperties: false,
+      },
+    };
+    expect(getConstraints(prop, false)).toEqual([]);
+  });
+
+  it('should not emit item constraints when items use if/then conditionals', () => {
+    const prop = {
+      type: 'array',
+      items: {
+        if: { properties: { kind: { const: 'a' } } },
+        then: { required: ['value'] },
+        enum: ['x'],
+      },
+    };
+    expect(getConstraints(prop, false)).toEqual([]);
+  });
+
+  it('should ignore tuple-form items arrays', () => {
+    const prop = {
+      type: 'array',
+      items: [{ enum: ['a'] }, { enum: ['b'] }],
+    };
+    expect(getConstraints(prop, false)).toEqual([]);
+  });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
@@ -785,4 +785,33 @@ describe('schemaToTableData', () => {
     expect(choiceRow).toBeDefined();
     expect(choiceRow.isLastInGroup).toBe(true);
   });
+
+  it('captures enum constraints on array items', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        subscription_groups: {
+          type: 'array',
+          items: {
+            enum: [
+              'newsmail',
+              'engagement',
+              'customerPanel',
+              'specialoffers',
+              'promotedContent',
+            ],
+          },
+          description: 'Subscription group identifiers',
+        },
+      },
+    };
+    const tableData = schemaToTableData(schema);
+    const subscriptionGroupsProp = tableData.find(
+      (r) => r.name === 'subscription_groups',
+    );
+    expect(subscriptionGroupsProp).toBeDefined();
+    expect(subscriptionGroupsProp.constraints).toContain(
+      'enum: [newsmail, engagement, customerPanel, specialoffers, promotedContent]',
+    );
+  });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/schemaToTableData.test.js
@@ -793,6 +793,7 @@ describe('schemaToTableData', () => {
         subscription_groups: {
           type: 'array',
           items: {
+            type: 'string',
             enum: [
               'newsmail',
               'engagement',
@@ -811,7 +812,7 @@ describe('schemaToTableData', () => {
     );
     expect(subscriptionGroupsProp).toBeDefined();
     expect(subscriptionGroupsProp.constraints).toContain(
-      'enum: [newsmail, engagement, customerPanel, specialoffers, promotedContent]',
+      'items.enum: [newsmail, engagement, customerPanel, specialoffers, promotedContent]',
     );
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/getConstraints.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/getConstraints.js
@@ -69,5 +69,19 @@ export const getConstraints = (prop, isReq) => {
       }
     }
   }
+
+  // For array types, also capture constraints from items schema
+  if (prop.type === 'array' && prop.items && typeof prop.items === 'object') {
+    for (const keyword in constraintHandlers) {
+      if (prop.items[keyword] !== undefined) {
+        const handler = constraintHandlers[keyword];
+        const result = handler(prop.items[keyword]);
+        if (result) {
+          constraints.push(result);
+        }
+      }
+    }
+  }
+
   return constraints;
 };

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/getConstraints.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/getConstraints.js
@@ -54,33 +54,41 @@ const constraintHandlers = {
   not: (val) => formatNotConstraint(val),
 };
 
+function collectConstraints(schema, prefix = '') {
+  const constraints = [];
+  for (const keyword in constraintHandlers) {
+    if (schema[keyword] !== undefined) {
+      const result = constraintHandlers[keyword](schema[keyword]);
+      if (result) {
+        constraints.push(`${prefix}${result}`);
+      }
+    }
+  }
+  return constraints;
+}
+
+// Scalar array items get no rows of their own in the docs table (only object
+// or conditional items are expanded), so surface their constraints here.
+function isScalarItemsSchema(items) {
+  return (
+    items &&
+    typeof items === 'object' &&
+    !Array.isArray(items) &&
+    !items.properties &&
+    !items.if
+  );
+}
+
 export const getConstraints = (prop, isReq) => {
   const constraints = [];
   if (isReq) {
     constraints.push('required');
   }
 
-  for (const keyword in constraintHandlers) {
-    if (prop[keyword] !== undefined) {
-      const handler = constraintHandlers[keyword];
-      const result = handler(prop[keyword]);
-      if (result) {
-        constraints.push(result);
-      }
-    }
-  }
+  constraints.push(...collectConstraints(prop));
 
-  // For array types, also capture constraints from items schema
-  if (prop.type === 'array' && prop.items && typeof prop.items === 'object') {
-    for (const keyword in constraintHandlers) {
-      if (prop.items[keyword] !== undefined) {
-        const handler = constraintHandlers[keyword];
-        const result = handler(prop.items[keyword]);
-        if (result) {
-          constraints.push(result);
-        }
-      }
-    }
+  if (prop.type === 'array' && isScalarItemsSchema(prop.items)) {
+    constraints.push(...collectConstraints(prop.items, 'items.'));
   }
 
   return constraints;


### PR DESCRIPTION
## Summary
Surface constraints from scalar array items (enums, patterns, etc.) in schema documentation tables with proper prefixing to avoid confusion.

## Changes
- Enhanced `getConstraints()` to inspect array item schemas for constraint keywords
- Prefix item-level constraints with "items." to distinguish from array-level constraints (e.g. `items.enum` vs `minItems`)
- Extracted constraint collection into a reusable helper function, eliminating code duplication
- Skip object items (`properties`) and conditional items (`if/then/else`) since those already expand into their own rows in the table

## Examples
Before: array of enum strings showed no constraints
```
subscription_groups: array (no constraints)
```

After: enum constraint on items now visible with proper prefix
```
subscription_groups: array (items.enum: [newsmail, engagement, ...])
```

## Test Plan
- ✅ All 965 tests pass (including 6 new unit tests covering enum, non-enum, collision avoidance, and skip cases)
- ✅ Pre-commit hooks validated schemas, linting, and dependencies
- ✅ Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)