### PR TITLE
Support configurable edit URL base

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -30,6 +30,7 @@ npm install --save docusaurus-plugin-generate-schema-docs
           {
             // Options if any
             dataLayerName: 'customDataLayer',
+            editUrlBase: 'https://gitlab.example/group/project/-/edit/main',
             trackingTargets: [
               {
                 id: 'web-custom-js',
@@ -48,6 +49,11 @@ npm install --save docusaurus-plugin-generate-schema-docs
     ```
 
     The `dataLayerName` option allows you to customize the name of the data layer variable in the generated examples. If not provided, it defaults to `dataLayer`.
+
+    The `editUrlBase` option customizes the generated `custom_edit_url` front
+    matter. Use it for GitLab or other repository hosts whose edit URL format
+    differs from GitHub. If omitted, edit URLs default to
+    `https://github.com/<organizationName>/<projectName>/edit/main/<schema-path>`.
 
 2.  Place your JSON schemas in the `schemas` directory at the root of your project.
 

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/generateEventDocs.test.js
@@ -145,6 +145,41 @@ describe('generateEventDocs (non-versioned)', () => {
     expect(customTargetDoc).toContain('"id":"web-custom-js"');
     expect(customTargetDoc).toContain('custom.track(\\"custom_event\\");');
   });
+
+  it('uses configured edit URL base for generated edit links', async () => {
+    console.log = jest.fn();
+    const relative = path.relative;
+    const relativeSpy = jest
+      .spyOn(path, 'relative')
+      .mockImplementation((from, to) =>
+        relative(from, to).replace(/\//g, '\\'),
+      );
+
+    try {
+      await generateEventDocs({
+        ...options,
+        editUrlBase: 'https://gitlab.example/group/project/-/edit/main',
+      });
+    } finally {
+      relativeSpy.mockRestore();
+    }
+
+    const addToCart = fs.readFileSync(
+      path.join(outputDir, 'add-to-cart-event.mdx'),
+      'utf-8',
+    );
+    expect(addToCart).toContain(
+      'custom_edit_url: https://gitlab.example/group/project/-/edit/main/__fixtures__/static/schemas/add-to-cart-event.json',
+    );
+
+    const rootChoiceA = fs.readFileSync(
+      path.join(outputDir, 'root-choice-event', '01-option-a.mdx'),
+      'utf-8',
+    );
+    expect(rootChoiceA).toContain(
+      'custom_edit_url: https://gitlab.example/group/project/-/edit/main/__fixtures__/static/schemas/root-choice-event.json',
+    );
+  });
 });
 
 describe('generateEventDocs (edge cases)', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -186,7 +186,12 @@ describe('plugin structure', () => {
   });
 
   it('passes all pluginOptions properties to generateEventDocs', async () => {
-    const plugin = await createPlugin(makeContext(), makeOptions());
+    const plugin = await createPlugin(
+      makeContext(),
+      makeOptions({
+        editUrlBase: 'https://gitlab.example/group/project/-/edit/main',
+      }),
+    );
     await plugin.loadContent();
 
     expect(generateEventDocs).toHaveBeenCalledWith(
@@ -196,6 +201,7 @@ describe('plugin structure', () => {
         siteDir: '/site',
         url: 'https://example.com',
         dataLayerName: 'dataLayer',
+        editUrlBase: 'https://gitlab.example/group/project/-/edit/main',
       }),
     );
   });

--- a/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/generateEventDocs.js
@@ -14,9 +14,20 @@ import processSchema from './helpers/processSchema.js';
 import { buildExampleModel } from './helpers/exampleModel.js';
 import { createTrackingTargetRegistry } from './helpers/snippetTargets.js';
 
-function buildEditUrl(organizationName, projectName, siteDir, filePath) {
-  const baseEditUrl = `https://github.com/${organizationName}/${projectName}/edit/main`;
-  return `${baseEditUrl}/${path.relative(path.join(siteDir, '..'), filePath)}`;
+function buildEditUrl(
+  organizationName,
+  projectName,
+  siteDir,
+  filePath,
+  editUrlBase,
+) {
+  const baseEditUrl = (
+    editUrlBase ||
+    `https://github.com/${organizationName}/${projectName}/edit/main`
+  ).replace(/\/+$/, '');
+  return `${baseEditUrl}/${path
+    .relative(path.join(siteDir, '..'), filePath)
+    .replace(/\\/g, '/')}`;
 }
 
 function toSiteImportPath(siteDir, absolutePath) {
@@ -161,6 +172,7 @@ async function generateAndWriteDoc(
     dataLayerName,
     version,
     targetRegistry,
+    editUrlBase,
   } = options;
 
   const { outputDir: versionOutputDir } = getPathsForVersion(version, siteDir);
@@ -198,6 +210,7 @@ async function generateAndWriteDoc(
     projectName,
     siteDir,
     editFilePath || filePath,
+    editUrlBase,
   );
 
   const mdxContent = SchemaDocTemplate({
@@ -232,12 +245,13 @@ async function generateOneOfDocs(
   schemaSources,
   schemaDir,
 ) {
-  const { organizationName, projectName, siteDir } = options;
+  const { organizationName, projectName, siteDir, editUrlBase } = options;
   const editUrl = buildEditUrl(
     organizationName,
     projectName,
     siteDir,
     filePath,
+    editUrlBase,
   );
 
   const eventOutputDir = path.join(outputDir, eventName);

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -72,7 +72,7 @@ async function syncVersionFromNext({
 
 export default async function (context, options) {
   const { siteDir } = context;
-  const { dataLayerName, trackingTargets = [] } = options || {};
+  const { dataLayerName, trackingTargets = [], editUrlBase } = options || {};
   const { organizationName, projectName, url } = context.siteConfig;
   const targetRegistry = createTrackingTargetRegistry({
     customTargets: trackingTargets,
@@ -85,6 +85,7 @@ export default async function (context, options) {
     url,
     dataLayerName,
     trackingTargets,
+    editUrlBase,
   };
   const versionsJsonPath = path.join(siteDir, 'versions.json');
   const isVersioned = fs.existsSync(versionsJsonPath);


### PR DESCRIPTION
## Summary
- add an editUrlBase plugin option for non-GitHub edit URLs such as GitLab
- thread the option into generated schema doc edit links
- normalize generated edit URL path separators for Windows-style paths

## Tests
- npm test
- npm run validate-schemas -w demo
- npm run lint