### PR TITLE
Dedupe control row style construction

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/continuingLinesStyle.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/continuingLinesStyle.test.js
@@ -4,6 +4,7 @@ import {
   getBracketLinesStyle,
   mergeBackgroundStyles,
   getContinuingLinesStyle,
+  getControlRowStyles,
 } from '../../helpers/continuingLinesStyle';
 
 describe('getBracketPosition', () => {
@@ -488,5 +489,30 @@ describe('getContinuingLinesStyle', () => {
     const result = getContinuingLinesStyle([0], 0);
     // Only one size entry for one continuing level
     expect(result.backgroundSize.split(', ').length).toBe(1);
+  });
+});
+
+describe('getControlRowStyles', () => {
+  it('builds shared header, middle, and closed-last styles for control rows', () => {
+    const parentBracket = { level: 0, bracketIndex: 0 };
+    const result = getControlRowStyles({
+      level: 2,
+      continuingLevels: [0, 1],
+      groupBrackets: [parentBracket],
+      parentBracketEnds: [parentBracket],
+    });
+
+    expect(result.ownBracket).toEqual({ level: 2, bracketIndex: 1 });
+    expect(result.headerStyle.paddingLeft).toBe('3rem');
+    expect(result.headerStyle.paddingTop).toBe('0.5rem');
+    expect(result.headerStyle.backgroundPosition).toContain('top 6px');
+
+    expect(result.middleStyle.paddingLeft).toBe('3rem');
+    expect(result.middleStyle).not.toHaveProperty('paddingTop');
+    expect(result.middleStyle).not.toHaveProperty('paddingBottom');
+
+    expect(result.lastToggleStyle.paddingLeft).toBe('3rem');
+    expect(result.lastToggleStyle.paddingBottom).toBe('0.5rem');
+    expect(result.lastToggleStyle.backgroundPosition).toContain('bottom 6px');
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/components/ConditionalRows.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/ConditionalRows.js
@@ -1,11 +1,7 @@
 import React, { useState, useId } from 'react';
 import SchemaRows from './SchemaRows';
 import clsx from 'clsx';
-import {
-  getContinuingLinesStyle,
-  getBracketLinesStyle,
-  mergeBackgroundStyles,
-} from '../helpers/continuingLinesStyle';
+import { getControlRowStyles } from '../helpers/continuingLinesStyle';
 
 /**
  * Renders 'if/then/else' conditionals as a set of `<tr>` elements
@@ -31,64 +27,13 @@ export default function ConditionalRows({
   const [activeBranch, setActiveBranch] = useState(0);
   const radioGroupId = useId();
 
-  // Compute this group's own bracket and combine with any parent brackets.
-  // bracketIndex = total number of existing brackets, so each group gets a unique position.
-  const ownBracket = {
-    level,
-    bracketIndex: groupBrackets.length,
-  };
-  const allBrackets = [...groupBrackets, ownBracket];
-
-  // colSpan=5 rows need continuing ancestor lines to pass through (for visual
-  // continuity). They don't have ::before/::after connectors, so we draw all
-  // ancestor lines via background gradients. We always include the immediate
-  // parent level (level-1) so the parent-to-child connector passes through.
-  // Only draw ancestor lines where the next level up is also continuing;
-  // this matches PropertyRow's filter to avoid stray lines at a parent's
-  // corner connector when that parent is the last in its group.
-  const ancestorLevels = continuingLevels.filter(
-    (lvl) => lvl < level && continuingLevels.includes(lvl + 1),
-  );
-  // Always include the immediate parent level so the parent-to-child
-  // connector passes through these full-width rows.
-  if (level > 0 && !ancestorLevels.includes(level - 1)) {
-    ancestorLevels.push(level - 1);
-  }
-  const treePassthrough = getContinuingLinesStyle(ancestorLevels, 0);
-  const indent = { paddingLeft: `${level * 1.25 + 0.5}rem` };
-
-  // If header: top cap on ownBracket
-  const headerBracketStyle = getBracketLinesStyle(allBrackets, {
-    starting: [ownBracket],
-  });
-  const headerMerged = mergeBackgroundStyles(
-    treePassthrough,
-    headerBracketStyle,
-  );
-  const headerStyle = { ...headerMerged, ...indent, paddingTop: '0.5rem' };
-
-  // Middle rows (branch toggles): no caps
-  const middleBracketStyle = getBracketLinesStyle(allBrackets);
-  const middleMerged = mergeBackgroundStyles(
-    treePassthrough,
-    middleBracketStyle,
-  );
-  const middleStyle = { ...middleMerged, ...indent };
-
-  // Last branch toggle when content is NOT shown: bottom cap (+ parent ends)
-  const allEndings = [ownBracket, ...(parentBracketEnds || [])];
-  const lastToggleBracketStyle = getBracketLinesStyle(allBrackets, {
-    ending: allEndings,
-  });
-  const lastToggleMerged = mergeBackgroundStyles(
-    treePassthrough,
-    lastToggleBracketStyle,
-  );
-  const lastToggleStyle = {
-    ...lastToggleMerged,
-    ...indent,
-    paddingBottom: '0.5rem',
-  };
+  const { ownBracket, headerStyle, middleStyle, lastToggleStyle } =
+    getControlRowStyles({
+      level,
+      continuingLevels,
+      groupBrackets,
+      parentBracketEnds,
+    });
 
   return (
     <>

--- a/packages/docusaurus-plugin-generate-schema-docs/components/FoldableRows.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/FoldableRows.js
@@ -2,11 +2,7 @@ import React, { useState, useId } from 'react';
 import SchemaRows from './SchemaRows';
 import Heading from '@theme/Heading';
 import clsx from 'clsx';
-import {
-  getContinuingLinesStyle,
-  getBracketLinesStyle,
-  mergeBackgroundStyles,
-} from '../helpers/continuingLinesStyle';
+import { getControlRowStyles } from '../helpers/continuingLinesStyle';
 
 // A clickable row that acts as a header/summary for a foldable choice
 const ChoiceRow = ({
@@ -79,64 +75,13 @@ export default function FoldableRows({
     selectTitle
   );
 
-  // Compute this group's own bracket and combine with any parent brackets.
-  // bracketIndex = total number of existing brackets, so each group gets a unique position.
-  const ownBracket = {
-    level,
-    bracketIndex: groupBrackets.length,
-  };
-  const allBrackets = [...groupBrackets, ownBracket];
-
-  // colSpan=5 rows need continuing ancestor lines to pass through (for visual
-  // continuity). They don't have ::before/::after connectors, so we draw all
-  // ancestor lines via background gradients. We always include the immediate
-  // parent level (level-1) so the parent-to-child connector passes through.
-  // Only draw ancestor lines where the next level up is also continuing;
-  // this matches PropertyRow's filter to avoid stray lines at a parent's
-  // corner connector when that parent is the last in its group.
-  const ancestorLevels = continuingLevels.filter(
-    (lvl) => lvl < level && continuingLevels.includes(lvl + 1),
-  );
-  // Always include the immediate parent level so the parent-to-child
-  // connector passes through these full-width rows.
-  if (level > 0 && !ancestorLevels.includes(level - 1)) {
-    ancestorLevels.push(level - 1);
-  }
-  const treePassthrough = getContinuingLinesStyle(ancestorLevels, 0);
-  const indent = { paddingLeft: `${level * 1.25 + 0.5}rem` };
-
-  // Header row: top cap on the ownBracket
-  const headerBracketStyle = getBracketLinesStyle(allBrackets, {
-    starting: [ownBracket],
-  });
-  const headerMerged = mergeBackgroundStyles(
-    treePassthrough,
-    headerBracketStyle,
-  );
-  const headerStyle = { ...headerMerged, ...indent, paddingTop: '0.5rem' };
-
-  // Middle rows (option toggles): no caps
-  const middleBracketStyle = getBracketLinesStyle(allBrackets);
-  const middleMerged = mergeBackgroundStyles(
-    treePassthrough,
-    middleBracketStyle,
-  );
-  const middleStyle = { ...middleMerged, ...indent };
-
-  // Last toggle when its content is NOT shown: bottom cap on ownBracket (+ parent ends)
-  const allEndings = [ownBracket, ...(parentBracketEnds || [])];
-  const lastToggleBracketStyle = getBracketLinesStyle(allBrackets, {
-    ending: allEndings,
-  });
-  const lastToggleMerged = mergeBackgroundStyles(
-    treePassthrough,
-    lastToggleBracketStyle,
-  );
-  const lastToggleStyle = {
-    ...lastToggleMerged,
-    ...indent,
-    paddingBottom: '0.5rem',
-  };
+  const { ownBracket, headerStyle, middleStyle, lastToggleStyle } =
+    getControlRowStyles({
+      level,
+      continuingLevels,
+      groupBrackets,
+      parentBracketEnds,
+    });
 
   return (
     <>

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/continuingLinesStyle.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/continuingLinesStyle.js
@@ -167,3 +167,46 @@ export const getContinuingLinesStyle = (continuingLevels = [], level = 0) => {
     backgroundRepeat: 'no-repeat',
   };
 };
+
+export const getControlRowStyles = ({
+  level = 0,
+  continuingLevels = [],
+  groupBrackets = [],
+  parentBracketEnds = [],
+}) => {
+  const ownBracket = {
+    level,
+    bracketIndex: groupBrackets.length,
+  };
+  const allBrackets = [...groupBrackets, ownBracket];
+  const ancestorLevels = continuingLevels.filter(
+    (lvl) => lvl < level && continuingLevels.includes(lvl + 1),
+  );
+  if (level > 0 && !ancestorLevels.includes(level - 1)) {
+    ancestorLevels.push(level - 1);
+  }
+
+  const treePassthrough = getContinuingLinesStyle(ancestorLevels, 0);
+  const indent = { paddingLeft: `${level * 1.25 + 0.5}rem` };
+  const buildStyle = (caps, extra = {}) => ({
+    ...mergeBackgroundStyles(
+      treePassthrough,
+      getBracketLinesStyle(allBrackets, caps),
+    ),
+    ...indent,
+    ...extra,
+  });
+
+  return {
+    ownBracket,
+    headerStyle: buildStyle(
+      { starting: [ownBracket] },
+      { paddingTop: '0.5rem' },
+    ),
+    middleStyle: buildStyle(),
+    lastToggleStyle: buildStyle(
+      { ending: [ownBracket, ...parentBracketEnds] },
+      { paddingBottom: '0.5rem' },
+    ),
+  };
+};


### PR DESCRIPTION
## Summary
- add a shared getControlRowStyles helper for choice/conditional table control rows
- replace duplicated bracket and connector style setup in FoldableRows and ConditionalRows
- cover the extracted helper with a focused unit test

## Verification
- npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/continuingLinesStyle.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/components/FoldableRows.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/components/ConditionalRows.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/components/ConnectorLines.visualRegression.test.js --runInBand
- pre-commit hook: npm run check:deps, npm test, npm run validate-schemas, npm run lint