### PR TITLE
Fix unversioned schema validation path

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -63,10 +63,12 @@ beforeEach(() => {
   fs.cpSync.mockImplementation(() => {});
   fs.rmSync.mockImplementation(() => {});
   execSync.mockImplementation(() => {});
-  getPathsForVersion.mockReturnValue({
-    schemaDir: '/site/static/schemas/next',
+  getPathsForVersion.mockImplementation((version) => ({
+    schemaDir: version
+      ? `/site/static/schemas/${version}`
+      : '/site/static/schemas',
     outputDir: '/site/docs',
-  });
+  }));
 });
 
 describe('loadContent', () => {
@@ -135,7 +137,21 @@ describe('extendCli - validate-schemas', () => {
     );
   });
 
-  it('defaults to "next" version when no version argument given', async () => {
+  it('defaults to unversioned schemas when no version argument is given and the site is not versioned', async () => {
+    const { cli, action } = makeCli();
+    const plugin = await createPlugin(makeContext(), makeOptions());
+    plugin.extendCli(cli);
+
+    await action.fn(undefined);
+    expect(getPathsForVersion).toHaveBeenCalledWith(undefined, '/site');
+    expect(validateSchemas).toHaveBeenCalledWith(
+      '/site/static/schemas',
+      expect.objectContaining({ targetRegistry: expect.any(Object) }),
+    );
+  });
+
+  it('defaults to next schemas when no version argument is given and the site is versioned', async () => {
+    fs.existsSync.mockReturnValue(true);
     const { cli, action } = makeCli();
     const plugin = await createPlugin(makeContext(), makeOptions());
     plugin.extendCli(cli);

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -95,7 +95,7 @@ export default async function (context, options) {
       .description('Validate JSON Schemas with the examples inside the schemas')
       .action(async (version) => {
         console.log('Validating GTM Schemas...');
-        const schemaVersion = version || 'next';
+        const schemaVersion = version || (isVersioned ? 'next' : undefined);
         const { schemaDir } = getPathsForVersion(
           schemaVersion,
           context.siteDir,


### PR DESCRIPTION
Summary: Default validate-schemas to static/schemas when versioning is disabled, while keeping versioned sites on static/schemas/next. Added CLI tests for both defaults. Tests: npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js --runInBand; npm run validate-schemas -w demo; commit hook ran full npm test, npm run validate-schemas, and npm run lint (lint printed: exclusiveMinimum is not boolean but did not block the commit).