### PR TITLE
Make web-datalayer-js a first-party target

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -59,7 +59,7 @@ npm install --save docusaurus-plugin-generate-schema-docs
 
 ## Custom Tracking Targets
 
-Use `trackingTargets` to add snippet targets that schemas can select with `x-tracking-targets`.
+Use `trackingTargets` to add custom tracking targets that schemas can select with `x-tracking-targets`.
 
 ```json
 {
@@ -143,9 +143,9 @@ By default, it resolves schemas from the project root. Use `--path=<siteDir>` to
 
 Only schemas tagged with `x-tracking-targets` including `web-datalayer-js` are used for GTM variable sync. Untagged schemas are ignored.
 
-### Snippet Targets
+### Built-In Tracking Targets
 
-`ExampleDataLayer` supports web snippet targets for:
+The plugin includes web tracking targets for:
 
 - `web-datalayer-js`
 - `web-segment-js`
@@ -161,7 +161,7 @@ Braze Web SDK snippets support:
 
 #### Firebase
 
-`ExampleDataLayer` supports Firebase snippet targets for:
+The plugin includes Firebase tracking targets for:
 
 - `android-firebase-kotlin-sdk`
 - `android-firebase-java-sdk`

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/SchemaViewer.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/SchemaViewer.test.js
@@ -80,4 +80,24 @@ describe('SchemaViewer', () => {
 
     expect(screen.getByText('custom.track("custom_event");')).toBeVisible();
   });
+
+  it('uses generic code example headings for web data layer targets', () => {
+    const schema = {
+      title: 'Web Data Layer Event',
+      type: 'object',
+      'x-tracking-targets': ['web-datalayer-js'],
+      properties: {
+        event: { type: 'string', examples: ['web_event'] },
+      },
+    };
+
+    render(<SchemaViewer schema={schema} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Code Example' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'DataLayer Example' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/snippetTargets.test.js
@@ -1889,7 +1889,9 @@ describe('server-rudderstack-python snippet', () => {
   });
 
   it('has group=server and language=python', () => {
-    const target = getSnippetTarget('server-rudderstack-python');
+    const target = createTrackingTargetRegistry().get(
+      'server-rudderstack-python',
+    );
     expect(target.group).toBe('server');
     expect(target.language).toBe('python');
   });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -179,6 +179,22 @@ describe('extendCli - validate-schemas', () => {
     expect(targetRegistry.has('web-custom-js')).toBe(true);
   });
 
+  it('passes configured dataLayerName to schema validation', async () => {
+    const { cli, action } = makeCli();
+    const plugin = await createPlugin(
+      makeContext(),
+      makeOptions({ dataLayerName: 'customDataLayer' }),
+    );
+    plugin.extendCli(cli);
+
+    await action.fn('next');
+
+    expect(validateSchemas).toHaveBeenCalledWith(
+      '/site/static/schemas/next',
+      expect.objectContaining({ dataLayerName: 'customDataLayer' }),
+    );
+  });
+
   it('exits with code 1 when validation fails', async () => {
     validateSchemas.mockResolvedValue(false);
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/validateSchemas.test.js
@@ -182,6 +182,92 @@ describe('validateSchemas', () => {
     expect(errorMessages).toContain('x-custom-required must be true.');
   });
 
+  it('should fail when a tracking target cannot generate a snippet for an example', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          generateSnippet: ({ example }) => {
+            throw new Error(`Cannot generate ${example.event}.`);
+          },
+        },
+      ],
+    });
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        'x-tracking-targets': ['web-custom-js'],
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir, { targetRegistry });
+
+    expect(result).toBe(false);
+    const errorMessages = consoleErrorSpy.mock.calls
+      .map((c) => c[0])
+      .join('\n');
+    expect(errorMessages).toContain(
+      '[web-custom-js] Cannot generate test_event.',
+    );
+  });
+
+  it('should pass configured dataLayerName to tracking target snippet generation', async () => {
+    const schemaDir = path.join(tmpDir, 'schemas');
+    const targetRegistry = createTrackingTargetRegistry({
+      customTargets: [
+        {
+          id: 'web-custom-js',
+          group: 'web',
+          label: 'Custom Web SDK',
+          language: 'javascript',
+          generateSnippet: ({ dataLayerName }) => {
+            if (dataLayerName !== 'customDataLayer') {
+              throw new Error(`Unexpected dataLayerName: ${dataLayerName}`);
+            }
+            return 'custom.track();';
+          },
+        },
+      ],
+    });
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(schemaDir, 'event.json'),
+      JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        'x-tracking-targets': ['web-custom-js'],
+        properties: {
+          event: {
+            type: 'string',
+            const: 'test_event',
+          },
+        },
+        required: ['event'],
+      }),
+    );
+
+    const result = await validateSchemas(schemaDir, {
+      targetRegistry,
+      dataLayerName: 'customDataLayer',
+    });
+
+    expect(result).toBe(true);
+  });
+
   it('should treat falsy scalar examples as valid examples', async () => {
     const schemaDir = path.join(tmpDir, 'schemas');
     fs.mkdirSync(schemaDir, { recursive: true });

--- a/packages/docusaurus-plugin-generate-schema-docs/components/SchemaViewer.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/SchemaViewer.js
@@ -21,11 +21,7 @@ export default function SchemaViewer({
       Object.values(schema.properties).some(
         (prop) => prop.oneOf || prop.anyOf,
       ));
-  const targets = schema['x-tracking-targets'] ?? [];
-  const prefix = targets.includes('web-datalayer-js') ? 'DataLayer' : 'Code';
-  const exampleTitle = hasOneOfAnyOf
-    ? `${prefix} Examples`
-    : `${prefix} Example`;
+  const exampleTitle = hasOneOfAnyOf ? 'Code Examples' : 'Code Example';
 
   return (
     <div>

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -101,7 +101,10 @@ export default async function (context, options) {
           schemaVersion,
           context.siteDir,
         );
-        const success = await validateSchemas(schemaDir, { targetRegistry });
+        const success = await validateSchemas(schemaDir, {
+          targetRegistry,
+          dataLayerName,
+        });
         if (!success) {
           console.error('Validation failed.');
           process.exit(1);

--- a/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/validateSchemas.js
@@ -33,10 +33,42 @@ function validateTrackingTargetHooks({
   });
 }
 
+function formatTargetGenerationError(targetId, error) {
+  const message = error?.message || String(error);
+  return message.startsWith(`[${targetId}]`)
+    ? message
+    : `[${targetId}] ${message}`;
+}
+
+function validateTrackingTargetSnippet({
+  trackingTargets,
+  targetRegistry,
+  schema,
+  example,
+  dataLayerName,
+}) {
+  const errors = [];
+
+  trackingTargets.targets.forEach((targetId) => {
+    try {
+      targetRegistry.generateSnippet({
+        targetId,
+        example,
+        schema,
+        dataLayerName,
+      });
+    } catch (error) {
+      errors.push(formatTargetGenerationError(targetId, error));
+    }
+  });
+
+  return errors;
+}
+
 const validateSingleSchema = async (
   filePath,
   schemaPath,
-  { targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+  { targetRegistry = DEFAULT_TARGET_REGISTRY, dataLayerName } = {},
 ) => {
   const file = path.basename(filePath);
   const errors = [];
@@ -104,6 +136,16 @@ const validateSingleSchema = async (
         const result = validate(example);
         if (result.valid) {
           fileHasValidExample = true;
+          validateTrackingTargetSnippet({
+            trackingTargets,
+            targetRegistry,
+            schema: mergedSchema,
+            example,
+            dataLayerName,
+          }).forEach((error) => {
+            errors.push(`x Schema ${file} (option: ${title}) ${error}`);
+            allValid = false;
+          });
         } else {
           errors.push(
             `x Schema ${file} (option: ${title}) example data failed validation:`,
@@ -130,7 +172,7 @@ const validateSingleSchema = async (
 
 const validateSchemas = async (
   schemaPath,
-  { targetRegistry = DEFAULT_TARGET_REGISTRY } = {},
+  { targetRegistry = DEFAULT_TARGET_REGISTRY, dataLayerName } = {},
 ) => {
   const topLevelSchemaFiles = fs
     .readdirSync(schemaPath)
@@ -139,7 +181,10 @@ const validateSchemas = async (
   const results = await Promise.all(
     topLevelSchemaFiles.map((file) => {
       const filePath = path.join(schemaPath, file);
-      return validateSingleSchema(filePath, schemaPath, { targetRegistry });
+      return validateSingleSchema(filePath, schemaPath, {
+        targetRegistry,
+        dataLayerName,
+      });
     }),
   );
 


### PR DESCRIPTION
Closes #131

## Summary
- Treat validation as a real tracking-target adapter path by invoking generateSnippet for each valid example.
- Forward configured dataLayerName into validation so web-datalayer-js validates the same snippet shape docs generate.
- Remove the generic SchemaViewer DataLayer heading special case and tighten tracking target docs wording.

## Verification
- npm test -- --runInBand
- npm run lint
- git diff --check
- commit hook: check:deps, test, validate-schemas, lint