### PR TITLE
Simplify Jest and Stryker config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testEnvironment: '@stryker-mutator/jest-runner/jest-env/jsdom',
+  testEnvironment: 'jsdom',
   roots: ['<rootDir>/packages', '<rootDir>/scripts'],
   transformIgnorePatterns: [
     'node_modules/(?!(docusaurus-plugin-generate-schema-docs|@apidevtools/json-schema-ref-parser))',

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -5,10 +5,8 @@ const config = {
     configFile: 'jest.stryker.config.js',
   },
   mutate: [
-    'packages/*/!(*.test|*.spec).js',
     'packages/**/!(*.test|*.spec).js',
     '!packages/**/__tests__/**',
-    '!packages/**/__mocks__/**',
     '!packages/**/test-data/**',
     '!packages/**/scripts/**',
     '!packages/**/components/**',


### PR DESCRIPTION
## Summary
- use standard jsdom for normal Jest runs
- remove duplicate and dead Stryker mutate patterns

## Verification
- npm test -- --runInBand
- npm run test:coverage (lines 98.38%, branches 94.11%)
- npm run test:mutation (mutation score 82.90)