### PR TITLE
Add pluggable sync addons for tracking targets

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,10 @@ A contract that describes a trackable event payload.
 A destination-specific surface that a **Tracking Schema** can support.
 _Avoid_: Extension
 
+**Sync Addon**:
+adapter that projects **Tracking Schemas** into an external system.
+_Avoid_: Tracking Target
+
 **Tracking Reference**:
 A documented collection of **Tracking Schemas** for a coherent usage context.
 
@@ -21,11 +25,15 @@ A secondary identifier attached to a user profile when the primary user identity
 
 - A **Tracking Schema** supports one or more **Tracking Targets**.
 - A **Tracking Reference** contains one or more **Tracking Schemas**.
+- A **Sync Addon** may consume **Tracking Schemas** for one or more **Tracking Targets**.
 
 ## Example dialogue
 
 > **Dev:** "Should Braze be added as an extension?"
 > **Domain expert:** "Call it a **Tracking Target**; Braze is one destination-specific target a **Tracking Schema** can support."
+
+> **Dev:** "Should GTM variable sync become a **Tracking Target** method?"
+> **Domain expert:** "No, make it a **Sync Addon** so **Tracking Targets** stay focused on examples."
 
 ## Flagged ambiguities
 

--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -92,6 +92,32 @@ A target must define:
 
 `validateSchema` is optional. Return an array of error messages, a single error string, `{ errors: [...] }`, or a falsy value when the schema is valid.
 
+## Sync Addons
+
+Use `syncAddons` to add CLI sync workflows that project Tracking Schemas into external systems. Sync addons are separate from Tracking Targets; do not add sync methods to tracking target adapters.
+
+A sync addon must define:
+
+```javascript
+{
+  id: 'braze-event-sync',
+  command: 'sync-braze',
+  description: 'Synchronize Braze Events',
+  targetIds: ['web-braze-js'],
+  options: [['--api-key <apiKey>', 'Braze API key']],
+  collect({ siteDir, commandOptions, logger }) {
+    return { events: [] };
+  },
+  apply({ desiredState, config, logger }) {
+    return { updated: desiredState.events };
+  },
+}
+```
+
+`id` must be unique across built-in and custom sync addons. `command` registers the Docusaurus CLI command. `targetIds` declares which tracking targets the addon consumes. `collect` returns the desired external state from schemas or command inputs, and `apply` writes that desired state to the external system.
+
+The built-in GTM Data Layer sync addon registers `docusaurus sync-gtm` and consumes schemas tagged with `web-datalayer-js`.
+
 ## CLI Commands
 
 ### Generate Documentation

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -436,6 +436,72 @@ describe('extendCli - sync-gtm', () => {
   });
 });
 
+describe('extendCli - sync addons', () => {
+  it('registers configured sync addon commands', async () => {
+    const desiredState = { events: ['checkout_started'] };
+    const collect = jest.fn().mockResolvedValue(desiredState);
+    const apply = jest
+      .fn()
+      .mockResolvedValue({ updated: ['checkout_started'] });
+    let syncBrazeAction = null;
+    let syncBrazeCommand = null;
+    const cli = {
+      command: jest.fn((name) => {
+        const cmd = {
+          description: jest.fn().mockReturnThis(),
+          option: jest.fn().mockReturnThis(),
+          action: jest.fn((fn) => {
+            if (name === 'sync-braze') syncBrazeAction = fn;
+            return cmd;
+          }),
+        };
+        if (name === 'sync-braze') syncBrazeCommand = cmd;
+        return cmd;
+      }),
+    };
+    const syncAddon = {
+      id: 'braze-event-sync',
+      command: 'sync-braze',
+      description: 'Synchronize Braze Events',
+      targetIds: ['web-braze-js'],
+      options: [['--api-key <apiKey>', 'Braze API key']],
+      collect,
+      apply,
+    };
+
+    const plugin = await createPlugin(
+      makeContext(),
+      makeOptions({ syncAddons: [syncAddon] }),
+    );
+    plugin.extendCli(cli);
+
+    expect(cli.command).toHaveBeenCalledWith('sync-braze');
+    expect(syncBrazeCommand.description).toHaveBeenCalledWith(
+      'Synchronize Braze Events',
+    );
+    expect(syncBrazeCommand.option).toHaveBeenCalledWith(
+      '--api-key <apiKey>',
+      'Braze API key',
+    );
+
+    await syncBrazeAction({ apiKey: 'secret' });
+
+    expect(collect).toHaveBeenCalledWith({
+      siteDir: '/site',
+      commandOptions: { apiKey: 'secret' },
+      logger: console,
+    });
+    expect(apply).toHaveBeenCalledWith({
+      desiredState,
+      config: {
+        siteDir: '/site',
+        commandOptions: { apiKey: 'secret' },
+      },
+      logger: console,
+    });
+  });
+});
+
 describe('extendCli - version-with-schemas', () => {
   const getAction = async () => {
     let captured = null;

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js
@@ -12,6 +12,45 @@ jest.mock('fs');
 jest.mock('child_process');
 jest.mock('@apidevtools/json-schema-ref-parser');
 
+describe('gtmDataLayerSyncAddon', () => {
+  it('represents GTM sync as an addon for web data layer schemas', async () => {
+    const desiredState = [{ name: 'event', description: 'Event name' }];
+    const summary = { created: ['event'], deleted: [], failedDeletes: [] };
+    const getVariablesFromSchemas = jest.fn().mockResolvedValue(desiredState);
+    const syncGtmVariables = jest.fn().mockResolvedValue(summary);
+
+    expect(gtmScript.gtmDataLayerSyncAddon).toMatchObject({
+      id: 'gtm-datalayer-sync',
+      command: 'sync-gtm',
+      description: 'Synchronize GTM Data Layer Variables from JSON schemas',
+      targetIds: ['web-datalayer-js'],
+    });
+
+    await expect(
+      gtmScript.gtmDataLayerSyncAddon.collect({
+        schemaPath: '/site/static/schemas/next',
+        skipArraySubProperties: true,
+        getVariablesFromSchemas,
+      }),
+    ).resolves.toEqual(desiredState);
+    expect(getVariablesFromSchemas).toHaveBeenCalledWith(
+      '/site/static/schemas/next',
+      { skipArraySubProperties: true },
+    );
+
+    await expect(
+      gtmScript.gtmDataLayerSyncAddon.apply({
+        desiredState,
+        skipArraySubProperties: true,
+        syncGtmVariables,
+      }),
+    ).resolves.toEqual(summary);
+    expect(syncGtmVariables).toHaveBeenCalledWith(desiredState, {
+      skipArraySubProperties: true,
+    });
+  });
+});
+
 describe('parseArgs', () => {
   it('should parse --quiet, --json, and --skip-array-sub-properties flags', () => {
     const argv = [

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/syncAddons.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/syncAddons.js
@@ -1,0 +1,117 @@
+import path from 'path';
+import { execSync } from 'child_process';
+
+function normalizeSyncAddon(addon) {
+  if (!addon?.id || typeof addon.id !== 'string') {
+    throw new Error('Sync addon must define a string id.');
+  }
+  if (!addon.command || typeof addon.command !== 'string') {
+    throw new Error(`Sync addon "${addon.id}" must define a command.`);
+  }
+  if (!addon.description || typeof addon.description !== 'string') {
+    throw new Error(`Sync addon "${addon.id}" must define a description.`);
+  }
+  if (!Array.isArray(addon.targetIds)) {
+    throw new Error(`Sync addon "${addon.id}" must define targetIds.`);
+  }
+  if (typeof addon.collect !== 'function') {
+    throw new Error(`Sync addon "${addon.id}" must define collect.`);
+  }
+  if (typeof addon.apply !== 'function') {
+    throw new Error(`Sync addon "${addon.id}" must define apply.`);
+  }
+
+  return addon;
+}
+
+export function createSyncAddonRegistry({
+  builtInAddons = [],
+  customAddons = [],
+} = {}) {
+  const addonIds = new Set();
+  const addons = [...builtInAddons, ...customAddons].map(normalizeSyncAddon);
+
+  addons.forEach((addon) => {
+    if (addonIds.has(addon.id)) {
+      throw new Error(`Duplicate sync addon id: ${addon.id}`);
+    }
+    addonIds.add(addon.id);
+  });
+
+  return addons;
+}
+
+export function createGtmDataLayerSyncAddon({ addon, pluginDir, siteDir }) {
+  return {
+    ...addon,
+    options: [
+      [
+        '--path <siteDir>',
+        'Docusaurus site directory containing static/schemas',
+        siteDir,
+      ],
+      ['--json', 'Output JSON summary'],
+      ['--quiet', 'Suppress non-error logs'],
+      [
+        '--skip-array-sub-properties',
+        'Skip array item sub-properties (e.g., list.0.item)',
+      ],
+    ],
+    collect({ commandOptions = {} }) {
+      return commandOptions;
+    },
+    apply({ desiredState: commandOptions = {} }) {
+      const scriptPath = path.join(pluginDir, 'scripts', 'sync-gtm.js');
+      const args = [`--path=${commandOptions.path}`];
+
+      if (commandOptions.json) args.push('--json');
+      if (commandOptions.quiet) args.push('--quiet');
+      if (commandOptions.skipArraySubProperties) {
+        args.push('--skip-array-sub-properties');
+      }
+
+      execSync(`node "${scriptPath}" ${args.join(' ')}`, {
+        cwd: siteDir,
+        stdio: 'inherit',
+      });
+    },
+  };
+}
+
+function addCommandOptions(command, options = []) {
+  options.forEach((option) => {
+    command.option(...option);
+  });
+}
+
+export function registerSyncAddonCommands(
+  cli,
+  syncAddonRegistry,
+  { siteDir, logger = console },
+) {
+  syncAddonRegistry.forEach((addon) => {
+    const command = cli.command(addon.command).description(addon.description);
+    addCommandOptions(command, addon.options);
+    command.action((commandOptions = {}) => {
+      const collectInput = {
+        siteDir,
+        commandOptions,
+        logger,
+      };
+      const applyInput = (desiredState) => ({
+        desiredState,
+        config: { siteDir, commandOptions },
+        logger,
+      });
+
+      const desiredState = addon.collect(collectInput);
+      if (desiredState && typeof desiredState.then === 'function') {
+        return desiredState.then((resolvedDesiredState) =>
+          addon.apply(applyInput(resolvedDesiredState)),
+        );
+      }
+
+      return addon.apply(applyInput(desiredState));
+    });
+  });
+}

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -4,9 +4,14 @@ import fs from 'fs';
 import validateSchemas from './validateSchemas.js';
 import generateEventDocs from './generateEventDocs.js';
 import path from 'path';
-import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { createTrackingTargetRegistry } from './helpers/snippetTargets.js';
+import gtmScript from './scripts/sync-gtm.js';
+import {
+  createGtmDataLayerSyncAddon,
+  createSyncAddonRegistry,
+  registerSyncAddonCommands,
+} from './helpers/syncAddons.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -72,10 +77,25 @@ async function syncVersionFromNext({
 
 export default async function (context, options) {
   const { siteDir } = context;
-  const { dataLayerName, trackingTargets = [], editUrlBase } = options || {};
+  const {
+    dataLayerName,
+    trackingTargets = [],
+    editUrlBase,
+    syncAddons = [],
+  } = options || {};
   const { organizationName, projectName, url } = context.siteConfig;
   const targetRegistry = createTrackingTargetRegistry({
     customTargets: trackingTargets,
+  });
+  const syncAddonRegistry = createSyncAddonRegistry({
+    builtInAddons: [
+      createGtmDataLayerSyncAddon({
+        addon: gtmScript.gtmDataLayerSyncAddon,
+        pluginDir: __dirname,
+        siteDir,
+      }),
+    ],
+    customAddons: syncAddons,
   });
 
   const pluginOptions = {
@@ -137,34 +157,7 @@ export default async function (context, options) {
         updateSchemaIds(siteDir, url, version);
       });
 
-    cli
-      .command('sync-gtm')
-      .description('Synchronize GTM Data Layer Variables from JSON schemas')
-      .option(
-        '--path <siteDir>',
-        'Docusaurus site directory that contains static/schemas',
-        siteDir,
-      )
-      .option('--json', 'Output JSON summary')
-      .option('--quiet', 'Suppress non-error logs')
-      .option(
-        '--skip-array-sub-properties',
-        'Skip array item sub-properties (e.g., list.0.item)',
-      )
-      .action((commandOptions) => {
-        const scriptPath = path.join(__dirname, 'scripts', 'sync-gtm.js');
-        const args = [`--path=${commandOptions.path}`];
-
-        if (commandOptions.json) args.push('--json');
-        if (commandOptions.quiet) args.push('--quiet');
-        if (commandOptions.skipArraySubProperties)
-          args.push('--skip-array-sub-properties');
-
-        execSync(`node "${scriptPath}" ${args.join(' ')}`, {
-          cwd: siteDir,
-          stdio: 'inherit',
-        });
-      });
+    registerSyncAddonCommands(cli, syncAddonRegistry, { siteDir });
 
     cli
       .command('version-with-schemas <version>')

--- a/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/scripts/sync-gtm.js
@@ -266,6 +266,27 @@ async function syncGtmVariables(
   };
 }
 
+const gtmDataLayerSyncAddon = {
+  id: 'gtm-datalayer-sync',
+  command: 'sync-gtm',
+  description: 'Synchronize GTM Data Layer Variables from JSON schemas',
+  targetIds: ['web-datalayer-js'],
+  collect({
+    schemaPath,
+    skipArraySubProperties = false,
+    getVariablesFromSchemas: getVars = getVariablesFromSchemas,
+  }) {
+    return getVars(schemaPath, { skipArraySubProperties });
+  },
+  apply({
+    desiredState,
+    skipArraySubProperties = false,
+    syncGtmVariables: sync = syncGtmVariables,
+  }) {
+    return sync(desiredState, { skipArraySubProperties });
+  },
+};
+
 async function setupGtmWorkspace() {
   const branchName =
     process.env.GTM_WORKSPACE_BRANCH ||
@@ -328,6 +349,7 @@ async function main(argv, deps) {
       getLatestSchemaPath: getPath,
       getVariablesFromSchemas: getVars,
       syncGtmVariables: sync,
+      syncAddon = gtmDataLayerSyncAddon,
       assertGtmCliAvailable: assertCli = assertGtmCliAvailable,
       logger: log,
       parseArgs: parse,
@@ -348,8 +370,10 @@ async function main(argv, deps) {
       );
     }
     log.log(`Scanning for schemas in: ${schemaPath}`);
-    const schemaVariables = await getVars(schemaPath, {
+    const schemaVariables = await syncAddon.collect({
+      schemaPath,
       skipArraySubProperties,
+      getVariablesFromSchemas: getVars,
     });
     if (schemaVariables.length === 0) {
       throw new Error(
@@ -358,7 +382,11 @@ async function main(argv, deps) {
     }
     log.log(`Found ${schemaVariables.length} variables defined in schemas.`);
 
-    const summary = await sync(schemaVariables, { skipArraySubProperties });
+    const summary = await syncAddon.apply({
+      desiredState: schemaVariables,
+      skipArraySubProperties,
+      syncGtmVariables: sync,
+    });
 
     if (isJson) {
       console.log(
@@ -425,4 +453,5 @@ module.exports = {
   parseArgs,
   assertGtmCliAvailable,
   setupGtmWorkspace,
+  gtmDataLayerSyncAddon,
 };


### PR DESCRIPTION
## Summary
- add a sync addon registry for built-in and configured addon commands
- register the existing GTM sync workflow through the registry without changing sync-gtm behavior
- document Sync Addon as distinct from Tracking Target

Closes #148

## Verification
- npm test -- packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js packages/docusaurus-plugin-generate-schema-docs/__tests__/syncGtm.test.js --runInBand
- npm run lint
- npm test -- --runInBand
- git diff --check
- commit hook: dependency check, Jest, schema validation, lint