### PR TITLE
Fix schema connector line continuity

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/ConnectorLines.visualRegression.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/ConnectorLines.visualRegression.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import FoldableRows from '../../components/FoldableRows';
 import ConditionalRows from '../../components/ConditionalRows';
+import SchemaRows from '../../components/SchemaRows';
 import { schemaToTableData } from '../../helpers/schemaToTableData';
 import battleTestSchema from '../__fixtures__/static/schemas/battle-test-event.json';
 
@@ -20,6 +21,11 @@ const getPropertyCellByName = (container, name) => {
   const strong = strongEls.find((el) => el.textContent === name);
   return strong?.closest('td');
 };
+
+const getPropertyCellsByName = (container, name) =>
+  Array.from(container.querySelectorAll('span.property-name > strong'))
+    .filter((el) => el.textContent === name)
+    .map((el) => el.closest('td'));
 
 describe('connector lines visual regressions', () => {
   const rows = schemaToTableData(battleTestSchema);
@@ -89,5 +95,119 @@ describe('connector lines visual regressions', () => {
     expect(cvvCell).toBeInTheDocument();
     expect(cvvCell).not.toHaveClass('is-last');
     expect(cvvCell.outerHTML).toMatchSnapshot();
+  });
+
+  it('keeps ancestor connector open through the last nested object before a root sibling', () => {
+    const schema = {
+      properties: {
+        branch_group: {
+          type: 'object',
+          properties: {
+            first_nested_branch: {
+              type: 'object',
+              properties: {
+                leaf_value: { type: 'string' },
+              },
+            },
+            last_nested_branch: {
+              type: 'object',
+              properties: {
+                leaf_value: { type: 'string' },
+              },
+            },
+          },
+        },
+        sibling_after_group: { type: 'array', items: { type: 'object' } },
+      },
+    };
+    const tableData = schemaToTableData(schema);
+
+    const { container } = renderInTable(<SchemaRows tableData={tableData} />);
+
+    const lastNestedBranchCell = getPropertyCellByName(
+      container,
+      'last_nested_branch',
+    );
+    expect(lastNestedBranchCell).toBeInTheDocument();
+    expect(lastNestedBranchCell).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
+
+    const leafCells = getPropertyCellsByName(container, 'leaf_value');
+    expect(leafCells).toHaveLength(2);
+    expect(leafCells[1]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
+  });
+
+  it('keeps nested sibling connectors open through leaf rows', () => {
+    const nestedLeafSchema = {
+      type: 'object',
+      properties: {
+        nested_leaf_holder: {
+          type: 'object',
+          properties: {
+            leaf_value: { type: 'string' },
+          },
+        },
+      },
+    };
+    const shallowLeafSchema = {
+      type: 'object',
+      properties: {
+        shallow_value: { type: 'string' },
+      },
+    };
+    const schema = {
+      properties: {
+        first_group: {
+          type: 'object',
+          properties: {
+            first_branch: nestedLeafSchema,
+            middle_branch: nestedLeafSchema,
+            last_branch: nestedLeafSchema,
+          },
+        },
+        second_group: {
+          type: 'object',
+          properties: {
+            first_branch: shallowLeafSchema,
+            middle_branch: shallowLeafSchema,
+            penultimate_branch: shallowLeafSchema,
+            last_branch: shallowLeafSchema,
+          },
+        },
+      },
+    };
+    const tableData = schemaToTableData(schema);
+
+    const { container } = renderInTable(<SchemaRows tableData={tableData} />);
+
+    const leafCells = getPropertyCellsByName(container, 'leaf_value');
+    expect(leafCells).toHaveLength(3);
+    expect(leafCells[0]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
+    expect(leafCells[0]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('1.75rem top'),
+    });
+    expect(leafCells[1]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
+    expect(leafCells[1]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('1.75rem top'),
+    });
+
+    const shallowValueCells = getPropertyCellsByName(
+      container,
+      'shallow_value',
+    );
+    expect(shallowValueCells).toHaveLength(4);
+    expect(shallowValueCells[0]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
+    expect(shallowValueCells[1]).toHaveStyle({
+      backgroundPosition: expect.stringContaining('0.5rem top'),
+    });
   });
 });

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertyRow.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertyRow.test.js
@@ -785,22 +785,21 @@ describe('PropertyRow', () => {
     });
 
     it('draws a pass-through line at the parent-level siblings connector when parent is not last', () => {
-      // Reproduces the visual gap between trial_end_date and is_trial.
-      // $time is level 3, the last child of trial_end_date (level 2, NOT last — is_trial follows).
-      // continuingLevels = [2] means trial_end_date is not last.
-      // The level-2 siblings connector (trial_end_date ↔ is_trial) sits at
+      // Reproduces the visual gap between branch_before_sibling and following_branch.
+      // leaf_value is level 3, the last child of branch_before_sibling (level 2, NOT last).
+      // continuingLevels = [2] means branch_before_sibling is not last.
+      // The level-2 siblings connector sits at
       // getLevelPosition(level - 2) = getLevelPosition(1) = 1.75rem.
-      // Without the fix there is no gradient at 1.75rem and the connector has a visual gap
-      // through $time's row.
+      // Without the line there is a connector gap through the leaf row.
       const row = {
-        name: '$time',
+        name: 'leaf_value',
         level: 3,
         required: true,
         propertyType: 'string',
-        description: 'ISO 8601 date string.',
-        examples: ['2025-12-30'],
-        constraints: ['required', 'format: date'],
-        path: ['PAYLOAD', 'products', '[n]', 'trial_end_date', '$time'],
+        description: 'Nested leaf value.',
+        examples: ['value'],
+        constraints: ['required'],
+        path: ['root', 'sibling_group', 'branch_before_sibling', 'leaf_value'],
         hasChildren: false,
         containerType: null,
         continuingLevels: [2],
@@ -818,6 +817,37 @@ describe('PropertyRow', () => {
 
       const td = container.querySelector('td.level-3');
       expect(td.style.backgroundPosition).toContain('1.75rem');
+    });
+
+    it('draws only bridged ancestor line when a continuing ancestor skips the parent level', () => {
+      const row = {
+        name: 'leaf_value',
+        level: 3,
+        required: true,
+        propertyType: 'string',
+        description: 'Nested leaf value.',
+        examples: ['2025-12-30'],
+        constraints: ['required'],
+        path: ['root', 'group_before_sibling', 'last_child', 'leaf_value'],
+        hasChildren: false,
+        containerType: null,
+        continuingLevels: [1],
+        groupBrackets: [],
+        isLastInGroup: true,
+      };
+
+      const { container } = render(
+        <table>
+          <tbody>
+            <PropertyRow row={row} isLastInGroup={true} />
+          </tbody>
+        </table>,
+      );
+
+      const td = container.querySelector('td.level-3');
+      expect(td).toHaveStyle({
+        backgroundPosition: '0.5rem top',
+      });
     });
 
     it('has no background-image when continuingLevels is empty and no children', () => {

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/__snapshots__/ConnectorLines.visualRegression.test.js.snap
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/__snapshots__/ConnectorLines.visualRegression.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`connector lines visual regressions keeps cvv row open when payment choice has following options 1`] = `"<td rowspan="1" style="padding-left: 1.75rem;" class="property-cell property-cell--tree level-1"><span class="property-name"><strong>cvv</strong></span></td>"`;
+exports[`connector lines visual regressions keeps cvv row open when payment choice has following options 1`] = `"<td rowspan="1" style="padding-left: 1.75rem; --connector-x: 0.5rem;" class="property-cell property-cell--tree level-1"><span class="property-name"><strong>cvv</strong></span></td>"`;
 
-exports[`connector lines visual regressions keeps user_id option row open when user conditional follows 1`] = `"<td rowspan="1" style="padding-left: 1.75rem;" class="property-cell property-cell--tree level-1"><span class="property-name"><strong>user_id</strong></span></td>"`;
+exports[`connector lines visual regressions keeps user_id option row open when user conditional follows 1`] = `"<td rowspan="1" style="padding-left: 1.75rem; --connector-x: 0.5rem;" class="property-cell property-cell--tree level-1"><span class="property-name"><strong>user_id</strong></span></td>"`;
 
-exports[`connector lines visual regressions keeps wallet_provider option row open when wallet_email follows 1`] = `"<td rowspan="2" style="padding-left: 1.75rem;" class="property-cell property-cell--required property-cell--tree level-1"><span class="property-name"><strong>wallet_provider</strong></span></td>"`;
+exports[`connector lines visual regressions keeps wallet_provider option row open when wallet_email follows 1`] = `"<td rowspan="2" style="padding-left: 1.75rem; --connector-x: 0.5rem;" class="property-cell property-cell--required property-cell--tree level-1"><span class="property-name"><strong>wallet_provider</strong></span></td>"`;

--- a/packages/docusaurus-plugin-generate-schema-docs/components/PropertyRow.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/PropertyRow.js
@@ -48,6 +48,12 @@ const KEYWORD_HELP_TEXT = {
 
 const SCHEMA_KEYWORD_BADGE_TEXT = 'Schema constraint';
 
+const TREE_LINE_GRADIENT =
+  'linear-gradient(var(--ifm-table-border-color), var(--ifm-table-border-color))';
+
+const CHILD_LINE_GRADIENT =
+  'linear-gradient(to bottom, transparent calc(50% + 1em), var(--ifm-table-border-color) calc(50% + 1em))';
+
 function splitKeywordLabel(name) {
   const match = /^patternProperties (\/.+\/)$/.exec(name);
   if (!match) {
@@ -112,69 +118,50 @@ export default function PropertyRow({
   // 1. Parent-to-child line (from 50% down) - for elements with children
   // 2. Continuing ancestor lines (full height) - for ancestors that have more siblings below
   //
-  // Position mapping: level N's line is at position (N * 1.25 + 0.5)rem
-  // This matches the CSS: level-1 at 0.5rem, level-2 at 1.75rem, etc.
+  // Position mapping: visual line N is at position (N * 1.25 + 0.5)rem.
   const getLevelPosition = (lvl) => lvl * 1.25 + 0.5;
+  const toVisualConnectorLevel = (lvl) => lvl - 1;
 
-  const allGradients = [];
-  const allSizes = [];
-  const allPositions = [];
+  const backgroundLayers = [];
+
+  const addBackgroundLine = (image, position) => {
+    backgroundLayers.push({ image, position, size: '1px 100%' });
+  };
 
   // Parent-to-child line: draws from 50% (below symbol) to bottom of cell
   if (hasChildren) {
     const childLevelPos = level * 1.25 + 0.5;
-    allGradients.push(
-      'linear-gradient(to bottom, transparent calc(50% + 1em), var(--ifm-table-border-color) calc(50% + 1em))',
-    );
-    allSizes.push('1px 100%');
-    allPositions.push(`${childLevelPos}rem top`);
+    addBackgroundLine(CHILD_LINE_GRADIENT, `${childLevelPos}rem top`);
   }
 
   // Continuing ancestor lines: full-height vertical lines for ancestors with more siblings.
-  // Only levels strictly below the immediate parent (< level - 1) are drawn here.
-  // The ::before pseudo-element handles the immediate parent connector at level - 1.
-  // We also require lvl+1 to be in continuingLevels: if the next level up is not continuing
-  // (i.e. the parent was the last sibling), drawing lvl's line would create a stray line at
-  // the same x-position as that parent's elbow.
-  continuingLevels
-    .filter((lvl) => lvl < level - 1 && continuingLevels.includes(lvl + 1))
-    .forEach((lvl) => {
-      const pos = getLevelPosition(lvl);
-      allGradients.push(
-        'linear-gradient(var(--ifm-table-border-color), var(--ifm-table-border-color))',
-      );
-      allSizes.push('1px 100%');
-      allPositions.push(`${pos}rem top`);
-    });
+  const visibleContinuingLevels = [
+    ...new Set(
+      continuingLevels
+        .map(toVisualConnectorLevel)
+        .filter((lvl) => lvl >= 0 && lvl < level - 1),
+    ),
+  ];
 
-  // When the immediate parent (level - 1) is not the last sibling at its level,
-  // the existing filter (lvl < level - 1) misses drawing the pass-through line at
-  // getLevelPosition(level - 2) — the x-position of the parent-level siblings connector.
-  // This gap makes visually disconnected siblings (e.g. trial_end_date ↔ is_trial when
-  // $time sits between them). Only add when level - 2 is not already in continuingLevels,
-  // which would mean the existing filter already handles it.
-  if (
-    level >= 2 &&
-    continuingLevels.includes(level - 1) &&
-    !continuingLevels.includes(level - 2)
-  ) {
-    const pos = getLevelPosition(level - 2);
-    allGradients.push(
-      'linear-gradient(var(--ifm-table-border-color), var(--ifm-table-border-color))',
-    );
-    allSizes.push('1px 100%');
-    allPositions.push(`${pos}rem top`);
-  }
+  visibleContinuingLevels.forEach((lvl) => {
+    addBackgroundLine(TREE_LINE_GRADIENT, `${getLevelPosition(lvl)}rem top`);
+  });
 
   const continuingLinesStyle =
-    allGradients.length > 0
+    backgroundLayers.length > 0
       ? {
-          backgroundImage: allGradients.join(', '),
-          backgroundSize: allSizes.join(', '),
-          backgroundPosition: allPositions.join(', '),
+          backgroundImage: backgroundLayers
+            .map(({ image }) => image)
+            .join(', '),
+          backgroundSize: backgroundLayers.map(({ size }) => size).join(', '),
+          backgroundPosition: backgroundLayers
+            .map(({ position }) => position)
+            .join(', '),
           backgroundRepeat: 'no-repeat',
         }
       : {};
+  const connectorPositionStyle =
+    level > 0 ? { '--connector-x': `${getLevelPosition(level - 1)}rem` } : {};
 
   // Bracket lines on the right side (description column)
   const bracketCaps = bracketEnds ? { ending: bracketEnds } : undefined;
@@ -208,7 +195,11 @@ export default function PropertyRow({
       >
         <td
           rowSpan={rowSpan}
-          style={{ ...indentStyle, ...continuingLinesStyle }}
+          style={{
+            ...indentStyle,
+            ...connectorPositionStyle,
+            ...continuingLinesStyle,
+          }}
           className={clsx(
             'property-cell',
             isSchemaKeywordRow && 'property-cell--keyword',

--- a/packages/docusaurus-plugin-generate-schema-docs/components/SchemaRows.css
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/SchemaRows.css
@@ -267,36 +267,9 @@ td[class*='level-']::after {
   pointer-events: none;
 }
 
-/* --- Level-based positioning --- */
-
-td.level-1::before,
-td.level-1::after {
-  left: 0.5rem;
-}
-
-td.level-2::before,
-td.level-2::after {
-  left: 1.75rem;
-}
-
-td.level-3::before,
-td.level-3::after {
-  left: 3rem;
-}
-
-td.level-4::before,
-td.level-4::after {
-  left: 4.25rem;
-}
-
-td.level-5::before,
-td.level-5::after {
-  left: 5.5rem;
-}
-
-td.level-6::before,
-td.level-6::after {
-  left: 6.75rem;
+td[class*='level-']::before,
+td[class*='level-']::after {
+  left: var(--connector-x);
 }
 
 /*


### PR DESCRIPTION
## Summary
- keep ancestor connector lines continuous through nested last-child rows
- remove the hard-coded connector depth ceiling by using a per-row connector position variable
- add generic connector regression fixtures without domain-specific schema keys

## Checks
- npm test -- --runInBand
- npm run lint
- npm run validate-schemas