### PR TITLE
Refactor eslint schema property guards

### DIFF
--- a/packages/eslint-plugin-tracking-schema/__tests__/property-definition.test.js
+++ b/packages/eslint-plugin-tracking-schema/__tests__/property-definition.test.js
@@ -6,6 +6,7 @@ const {
   isInsideIfBlock,
   isPureRef,
   isConstraintOnlyRefinement,
+  getCheckablePropertyDefinition,
 } = require('../helpers/property-definition');
 
 describe('PROPERTY_DEFINITION_SELECTOR', () => {
@@ -152,5 +153,105 @@ describe('getKeys', () => {
     };
     const keys = getKeys(definitionNode);
     expect(keys).toEqual(new Set(['type']));
+  });
+});
+
+describe('getCheckablePropertyDefinition', () => {
+  function makeNode({ key = { value: 'event' }, value, blockKey = 'then' }) {
+    const node = {
+      key,
+      value,
+      parent: {},
+    };
+    node.parent.parent = {
+      parent: {
+        parent: {
+          key: { value: blockKey },
+        },
+      },
+    };
+    return node;
+  }
+
+  it('returns definition node, keys, and property name for checkable property', () => {
+    const definitionNode = {
+      type: 'JSONObjectExpression',
+      properties: [
+        { key: { value: 'type' } },
+        { key: { value: 'description' } },
+      ],
+    };
+
+    expect(
+      getCheckablePropertyDefinition(makeNode({ value: definitionNode })),
+    ).toEqual({
+      definitionNode,
+      keys: new Set(['type', 'description']),
+      name: 'event',
+    });
+  });
+
+  it('falls back to key.name for JSON5 property names', () => {
+    const definitionNode = {
+      type: 'JSONObjectExpression',
+      properties: [{ key: { value: 'type' } }],
+    };
+
+    expect(
+      getCheckablePropertyDefinition(
+        makeNode({
+          key: { name: 'event', value: undefined },
+          value: definitionNode,
+        }),
+      ).name,
+    ).toBe('event');
+  });
+
+  it('returns null inside if blocks', () => {
+    expect(
+      getCheckablePropertyDefinition(
+        makeNode({
+          blockKey: 'if',
+          value: {
+            type: 'JSONObjectExpression',
+            properties: [{ key: { value: 'const' } }],
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for non-object property definitions', () => {
+    expect(
+      getCheckablePropertyDefinition(
+        makeNode({ value: { type: 'JSONLiteral', value: 'string' } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for pure refs', () => {
+    expect(
+      getCheckablePropertyDefinition(
+        makeNode({
+          value: {
+            type: 'JSONObjectExpression',
+            properties: [{ key: { value: '$ref' } }],
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for constraint-only refinements', () => {
+    expect(
+      getCheckablePropertyDefinition(
+        makeNode({
+          value: {
+            type: 'JSONObjectExpression',
+            properties: [{ key: { value: 'maxLength' } }],
+          },
+        }),
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/eslint-plugin-tracking-schema/helpers/property-definition.js
+++ b/packages/eslint-plugin-tracking-schema/helpers/property-definition.js
@@ -80,10 +80,27 @@ function isConstraintOnlyRefinement(keys) {
   return ![...keys].some((k) => ANNOTATION_OR_STRUCTURAL_KEYS.has(k));
 }
 
+function getCheckablePropertyDefinition(node) {
+  if (isInsideIfBlock(node)) return null;
+
+  const definitionNode = node.value;
+  if (definitionNode.type !== 'JSONObjectExpression') return null;
+
+  const keys = getKeys(definitionNode);
+  if (isPureRef(keys) || isConstraintOnlyRefinement(keys)) return null;
+
+  return {
+    definitionNode,
+    keys,
+    name: node.key.value ?? node.key.name,
+  };
+}
+
 module.exports = {
   PROPERTY_DEFINITION_SELECTOR,
   getKeys,
   isInsideIfBlock,
   isPureRef,
   isConstraintOnlyRefinement,
+  getCheckablePropertyDefinition,
 };

--- a/packages/eslint-plugin-tracking-schema/rules/require-description.js
+++ b/packages/eslint-plugin-tracking-schema/rules/require-description.js
@@ -1,9 +1,6 @@
 const {
   PROPERTY_DEFINITION_SELECTOR,
-  getKeys,
-  isInsideIfBlock,
-  isPureRef,
-  isConstraintOnlyRefinement,
+  getCheckablePropertyDefinition,
 } = require('../helpers/property-definition');
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -24,20 +21,14 @@ module.exports = {
   create(context) {
     return {
       [PROPERTY_DEFINITION_SELECTOR](node) {
-        if (isInsideIfBlock(node)) return;
+        const property = getCheckablePropertyDefinition(node);
+        if (!property) return;
 
-        const definitionNode = node.value;
-        if (definitionNode.type !== 'JSONObjectExpression') return;
-
-        const keys = getKeys(definitionNode);
-        if (isPureRef(keys)) return;
-        if (isConstraintOnlyRefinement(keys)) return;
-
-        if (!keys.has('description')) {
+        if (!property.keys.has('description')) {
           context.report({
             node,
             messageId: 'missing',
-            data: { name: node.key.value ?? node.key.name },
+            data: { name: property.name },
           });
         }
       },

--- a/packages/eslint-plugin-tracking-schema/rules/require-examples.js
+++ b/packages/eslint-plugin-tracking-schema/rules/require-examples.js
@@ -1,9 +1,6 @@
 const {
   PROPERTY_DEFINITION_SELECTOR,
-  getKeys,
-  isInsideIfBlock,
-  isPureRef,
-  isConstraintOnlyRefinement,
+  getCheckablePropertyDefinition,
 } = require('../helpers/property-definition');
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -24,14 +21,9 @@ module.exports = {
   create(context) {
     return {
       [PROPERTY_DEFINITION_SELECTOR](node) {
-        if (isInsideIfBlock(node)) return;
-
-        const definitionNode = node.value;
-        if (definitionNode.type !== 'JSONObjectExpression') return;
-
-        const keys = getKeys(definitionNode);
-        if (isPureRef(keys)) return;
-        if (isConstraintOnlyRefinement(keys)) return;
+        const property = getCheckablePropertyDefinition(node);
+        if (!property) return;
+        const { definitionNode, keys, name } = property;
 
         // const and enum already constrain the value — no example needed
         if (keys.has('const') || keys.has('enum')) return;
@@ -50,7 +42,7 @@ module.exports = {
           context.report({
             node,
             messageId: 'missing',
-            data: { name: node.key.value ?? node.key.name },
+            data: { name },
           });
         }
       },

--- a/packages/eslint-plugin-tracking-schema/rules/require-type.js
+++ b/packages/eslint-plugin-tracking-schema/rules/require-type.js
@@ -1,9 +1,6 @@
 const {
   PROPERTY_DEFINITION_SELECTOR,
-  getKeys,
-  isInsideIfBlock,
-  isPureRef,
-  isConstraintOnlyRefinement,
+  getCheckablePropertyDefinition,
 } = require('../helpers/property-definition');
 
 const TYPE_ALTERNATIVES = ['$ref', 'const', 'oneOf', 'anyOf', 'allOf'];
@@ -26,20 +23,17 @@ module.exports = {
   create(context) {
     return {
       [PROPERTY_DEFINITION_SELECTOR](node) {
-        if (isInsideIfBlock(node)) return;
+        const property = getCheckablePropertyDefinition(node);
+        if (!property) return;
 
-        const definitionNode = node.value;
-        if (definitionNode.type !== 'JSONObjectExpression') return;
-
-        const keys = getKeys(definitionNode);
-        if (isPureRef(keys)) return;
-        if (isConstraintOnlyRefinement(keys)) return;
-
-        if (!keys.has('type') && !TYPE_ALTERNATIVES.some((k) => keys.has(k))) {
+        if (
+          !property.keys.has('type') &&
+          !TYPE_ALTERNATIVES.some((k) => property.keys.has(k))
+        ) {
           context.report({
             node,
             messageId: 'missing',
-            data: { name: node.key.value ?? node.key.name },
+            data: { name: property.name },
           });
         }
       },


### PR DESCRIPTION
## Summary
- extract shared checkable property-definition guard for eslint schema rules
- update description/type/examples rules to use the shared guard
- add direct coverage for the shared guard skip and return behavior

## Tests
- npm test -- packages/eslint-plugin-tracking-schema --runInBand
- ./node_modules/.bin/eslint packages/eslint-plugin-tracking-schema/helpers/property-definition.js packages/eslint-plugin-tracking-schema/rules/require-description.js packages/eslint-plugin-tracking-schema/rules/require-type.js packages/eslint-plugin-tracking-schema/rules/require-examples.js packages/eslint-plugin-tracking-schema/__tests__/property-definition.test.js
- npm test -- --runInBand
- git diff --check