### PR TITLE
Expose example payload API

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,11 +21,19 @@ A documented collection of **Tracking Schemas** for a coherent usage context.
 **User Alias**:
 A secondary identifier attached to a user profile when the primary user identity is not the right identifier for a use case.
 
+**Profile Attribute**:
+A user profile field documented separately from event payload schemas.
+
+**Example Payload**:
+A sample data instance derived from a **Tracking Schema** for documentation or sync workflows.
+
 ## Relationships
 
 - A **Tracking Schema** supports one or more **Tracking Targets**.
 - A **Tracking Reference** contains one or more **Tracking Schemas**.
 - A **Sync Addon** may consume **Tracking Schemas** for one or more **Tracking Targets**.
+- A **Profile Attribute** may be sent alongside event examples but is not part of event payload.
+- An **Example Payload** may represent a default example or a named schema variant.
 
 ## Example dialogue
 

--- a/packages/docusaurus-plugin-generate-schema-docs/README.md
+++ b/packages/docusaurus-plugin-generate-schema-docs/README.md
@@ -118,6 +118,28 @@ A sync addon must define:
 
 The built-in GTM Data Layer sync addon registers `docusaurus sync-gtm` and consumes schemas tagged with `web-datalayer-js`.
 
+## Example Payload API
+
+Use `buildExamplePayloads(schema)` when a custom sync addon needs example data from a parsed JSON schema:
+
+```javascript
+import { buildExamplePayloads } from 'docusaurus-plugin-generate-schema-docs';
+
+const payloads = buildExamplePayloads(schema);
+```
+
+The helper is pure: pass a parsed schema object; handle file loading and `$ref` resolution in your addon. It returns one payload per generated example option and excludes `undefined` or empty object payloads:
+
+```javascript
+[
+  {
+    title: 'Enterprise',
+    variant: { property: 'plan', option: 'Enterprise' },
+    payload: { plan: 'enterprise' },
+  },
+];
+```
+
 ## CLI Commands
 
 ### Generate Documentation

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/examplePayloads.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/helpers/examplePayloads.test.js
@@ -1,0 +1,89 @@
+import { buildExamplePayloads } from '../../helpers/examplePayloads';
+
+describe('buildExamplePayloads', () => {
+  describe('when the schema produces a default example', () => {
+    it('returns payload metadata for the generated example', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          user_id: { type: 'string', examples: ['user-123'] },
+          plan: { type: 'string', examples: ['pro'] },
+        },
+      };
+
+      expect(buildExamplePayloads(schema)).toEqual([
+        {
+          title: 'Example',
+          variant: { property: 'default', option: 'Example' },
+          payload: {
+            user_id: 'user-123',
+            plan: 'pro',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('when a variant produces no useful payload', () => {
+    it('excludes undefined and empty object payloads', () => {
+      const schema = {
+        oneOf: [
+          {
+            title: 'Missing payload',
+            type: 'object',
+            properties: {},
+          },
+          {
+            title: 'Empty payload',
+            type: 'object',
+            examples: [{}],
+          },
+          {
+            title: 'Ready payload',
+            type: 'object',
+            properties: {
+              event: { const: 'ready' },
+            },
+          },
+        ],
+      };
+
+      expect(buildExamplePayloads(schema)).toEqual([
+        {
+          title: 'Ready payload',
+          variant: { property: 'root', option: 'Ready payload' },
+          payload: { event: 'ready' },
+        },
+      ]);
+    });
+  });
+
+  describe('when the schema has multiple usable variants', () => {
+    it('returns one payload for each variant option', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          plan: {
+            oneOf: [
+              { title: 'Free', const: 'free' },
+              { title: 'Enterprise', const: 'enterprise' },
+            ],
+          },
+        },
+      };
+
+      expect(buildExamplePayloads(schema)).toEqual([
+        {
+          title: 'Free',
+          variant: { property: 'plan', option: 'Free' },
+          payload: { plan: 'free' },
+        },
+        {
+          title: 'Enterprise',
+          variant: { property: 'plan', option: 'Enterprise' },
+          payload: { plan: 'enterprise' },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/index.test.js
@@ -2,7 +2,7 @@
  * @jest-environment @stryker-mutator/jest-runner/jest-env/node
  */
 
-import createPlugin from '../index.js';
+import createPlugin, { buildExamplePayloads } from '../index.js';
 
 jest.mock('url', () => ({
   fileURLToPath: jest.fn(
@@ -48,6 +48,12 @@ const makeContext = (overrides = {}) => ({
 const makeOptions = (overrides = {}) => ({
   dataLayerName: 'dataLayer',
   ...overrides,
+});
+
+describe('public exports', () => {
+  it('exports buildExamplePayloads for sync addons', () => {
+    expect(buildExamplePayloads).toEqual(expect.any(Function));
+  });
 });
 
 const makeCustomTarget = () => ({

--- a/packages/docusaurus-plugin-generate-schema-docs/helpers/examplePayloads.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/helpers/examplePayloads.js
@@ -1,0 +1,22 @@
+import { schemaToExamples } from './schemaToExamples';
+
+function hasUsefulPayload(payload) {
+  return (
+    typeof payload !== 'undefined' &&
+    (typeof payload !== 'object' ||
+      payload === null ||
+      Object.keys(payload).length > 0)
+  );
+}
+
+export function buildExamplePayloads(schema) {
+  return schemaToExamples(schema).flatMap((group) =>
+    group.options
+      .filter((option) => hasUsefulPayload(option.example))
+      .map((option) => ({
+        title: option.title,
+        variant: { property: group.property, option: option.title },
+        payload: option.example,
+      })),
+  );
+}

--- a/packages/docusaurus-plugin-generate-schema-docs/index.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/index.js
@@ -13,6 +13,8 @@ import {
   registerSyncAddonCommands,
 } from './helpers/syncAddons.js';
 
+export { buildExamplePayloads } from './helpers/examplePayloads.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function readConfiguredVersions(siteDir) {


### PR DESCRIPTION
Summary:
- Expose buildExamplePayloads as a top-level public API.
- Return sync-friendly example payload metadata from parsed schemas.
- Document Example Payload/Profile Attribute domain terms and usage.

Tests:
- npm test -- --runInBand
- pre-commit hook: check:deps, test, validate-schemas, lint