### PR TITLE
Fix sparse schema table alignment

### DIFF
--- a/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertiesTable.layout.test.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/__tests__/components/PropertiesTable.layout.test.js
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom';
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { render } from '@testing-library/react';
+import PropertiesTable from '../../components/PropertiesTable';
+
+const productCatalogSchema = {
+  type: 'object',
+  properties: Object.fromEntries(
+    [
+      ['id', 'string'],
+      ['product_key', 'string'],
+      ['locale', 'string'],
+      ['placement', 'string'],
+      ['priority', 'number'],
+      ['is_active', 'boolean'],
+      ['name', 'string'],
+      ['short_description', 'string'],
+      ['image_url', 'string'],
+      ['price_display', 'string'],
+      ['price_value', 'number'],
+      ['original_price_display', 'string'],
+      ['original_price_value', 'number'],
+      ['currency', 'string'],
+      ['discount_label', 'string'],
+      ['cta_text', 'string'],
+      ['cta_url', 'string'],
+      ['category', 'string'],
+      ['brand', 'string'],
+      ['recommendation_type', 'string'],
+      ['stock_status', 'string'],
+      ['start_date', 'string'],
+      ['end_date', 'string'],
+      ['background_color', 'string'],
+      ['text_color', 'string'],
+      ['tags', 'array'],
+      ['metadata', 'object'],
+    ].map(([name, type]) => [name, { type }]),
+  ),
+};
+
+describe('PropertiesTable layout', () => {
+  let style;
+
+  beforeEach(() => {
+    style = document.createElement('style');
+    style.textContent = `
+      table {
+        display: block;
+        overflow: auto;
+      }
+
+      ${fs.readFileSync(
+        path.join(__dirname, '../../components/PropertiesTable.module.css'),
+        'utf8',
+      )}
+
+      ${fs.readFileSync(
+        path.join(__dirname, '../../components/SchemaRows.css'),
+        'utf8',
+      )}
+    `;
+    document.head.append(style);
+  });
+
+  afterEach(() => {
+    style.remove();
+  });
+
+  it('keeps a sparse product catalog grid aligned with its border', () => {
+    const { getByRole } = render(
+      <PropertiesTable schema={productCatalogSchema} />,
+    );
+    const table = getByRole('table');
+    const rows = Array.from(table.tBodies[0].rows);
+    const tableStyle = getComputedStyle(table);
+    const scrollContainerStyle = getComputedStyle(table.parentElement);
+
+    expect({
+      rows: rows.length,
+      sparseRows: rows.every(
+        (row) =>
+          row.cells.length === 5 &&
+          Array.from(row.cells)
+            .slice(2)
+            .every((cell) => cell.textContent === ''),
+      ),
+      display: tableStyle.display,
+      width: tableStyle.width,
+      overflowX: scrollContainerStyle.overflowX,
+    }).toEqual({
+      rows: 27,
+      sparseRows: true,
+      display: 'table',
+      width: '100%',
+      overflowX: 'auto',
+    });
+  });
+});

--- a/packages/docusaurus-plugin-generate-schema-docs/components/PropertiesTable.js
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/PropertiesTable.js
@@ -52,12 +52,14 @@ export default function PropertiesTable({ schema, sourceSchema }) {
           isEnabled={isWordWrapOn}
         />
       </div>
-      <table className="schema-table">
-        <TableHeader />
-        <tbody>
-          <SchemaRows tableData={tableData} stripeState={stripeState} />
-        </tbody>
-      </table>
+      <div className={styles.tableScroller}>
+        <table className="schema-table">
+          <TableHeader />
+          <tbody>
+            <SchemaRows tableData={tableData} stripeState={stripeState} />
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/packages/docusaurus-plugin-generate-schema-docs/components/PropertiesTable.module.css
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/PropertiesTable.module.css
@@ -13,6 +13,10 @@
   min-width: 5.3rem;
 }
 
+.tableScroller {
+  overflow-x: auto;
+}
+
 .noWordWrap code {
   white-space: pre;
   word-break: normal;

--- a/packages/docusaurus-plugin-generate-schema-docs/components/SchemaRows.css
+++ b/packages/docusaurus-plugin-generate-schema-docs/components/SchemaRows.css
@@ -169,6 +169,8 @@
   border-collapse: separate;
   border-spacing: 0;
   border: 1px solid var(--ifm-table-border-color);
+  display: table;
+  width: 100%;
 }
 
 .schema-table th,


### PR DESCRIPTION
## Summary
- restore table layout semantics so sparse schema rows fill the outer border
- move horizontal overflow to a dedicated wrapper to preserve no-wrap behavior
- add a 27-row sparse product catalog regression test

## Testing
- npm test -- --runInBand (994 tests)
- npm run lint
- npm run build